### PR TITLE
Add lot renewal scheduler, epoch-aware quota stamping, and age-based purge

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1909,6 +1909,51 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 			return errors.New("If Cache.EnableLotman is true, the following Cache parameters must also be set: HighWaterMark, LowWaterMark, " +
 				"FilesBaseSize, FilesNominalSize, FilesMaxSize")
 		}
+		// Lotman boundary checks. These were previously scattered across
+		// the lotman package and xrootd config builder; consolidating
+		// them here means an operator sees one batch of errors at boot
+		// rather than discovering them only when the renewal scheduler
+		// or xrootd config is built.
+		const (
+			minPurgeAge = time.Hour
+			maxPurgeAge = 360 * 24 * time.Hour
+		)
+		if maxLife := param.Lotman_MaxLotLifetime.GetDuration(); maxLife > 0 {
+			// pfc.diskusage purgecoldfiles age must be in [1h, 360d]
+			// because Lotman.MaxLotLifetime is propagated verbatim to
+			// that xrootd directive when Cache.EnableLotman is true.
+			if maxLife < minPurgeAge {
+				return errors.Errorf("%s (%s) is below the minimum allowed value of 1h",
+					param.Lotman_MaxLotLifetime.GetName(), maxLife)
+			}
+			if maxLife > maxPurgeAge {
+				return errors.Errorf("%s (%s) exceeds the maximum allowed value of 360d",
+					param.Lotman_MaxLotLifetime.GetName(), maxLife)
+			}
+		}
+		// SchedulingHorizon should be ≥ DefaultLotExpirationLifetime and
+		// ≥ RenewalCheckInterval. Warn (don't reject) — the runtime
+		// planner additionally clamps up so a misconfigured value
+		// degrades gracefully rather than producing a coverage gap.
+		horizon := param.Lotman_SchedulingHorizon.GetDuration()
+		defLife := param.Lotman_DefaultLotExpirationLifetime.GetDuration()
+		interval := param.Lotman_RenewalCheckInterval.GetDuration()
+		if horizon > 0 && defLife > 0 && horizon < defLife {
+			log.Warnf("%s (%s) is shorter than %s (%s); the planner will treat the horizon as %s. Consider raising %s to at least %s.",
+				param.Lotman_SchedulingHorizon.GetName(), horizon,
+				param.Lotman_DefaultLotExpirationLifetime.GetName(), defLife,
+				defLife,
+				param.Lotman_SchedulingHorizon.GetName(),
+				param.Lotman_DefaultLotExpirationLifetime.GetName())
+		}
+		if horizon > 0 && interval > 0 && horizon < interval {
+			log.Warnf("%s (%s) is shorter than %s (%s); the planner will treat the horizon as %s. Consider raising %s to at least %s.",
+				param.Lotman_SchedulingHorizon.GetName(), horizon,
+				param.Lotman_RenewalCheckInterval.GetName(), interval,
+				interval,
+				param.Lotman_SchedulingHorizon.GetName(),
+				param.Lotman_RenewalCheckInterval.GetName())
+		}
 	}
 
 	if currentServers.IsEnabled(server_structs.DirectorType) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1419,3 +1419,89 @@ func TestConfigFileBootstrapping(t *testing.T) {
 		})
 	}
 }
+
+// setupCacheLotmanPrereqs configures the cache-side parameters that
+// InitServer's Cache.EnableLotman block requires before it inspects
+// Lotman-specific bounds. Tests that exercise the Lotman boundary
+// validators in InitServer should call this first, then override the
+// specific Lotman.* parameter under test.
+func setupCacheLotmanPrereqs(t *testing.T) {
+	require.NoError(t, param.ConfigDir.Set(t.TempDir()))
+	require.NoError(t, param.Cache_EnableLotman.Set(true))
+	require.NoError(t, param.Cache_LowWatermark.Set("80"))
+	require.NoError(t, param.Cache_HighWaterMark.Set("90"))
+	require.NoError(t, param.Cache_FilesBaseSize.Set("1g"))
+	require.NoError(t, param.Cache_FilesNominalSize.Set("2g"))
+	require.NoError(t, param.Cache_FilesMaxSize.Set("3g"))
+}
+
+// Lotman.MaxLotLifetime is propagated verbatim to the xrootd
+// pfc.diskusage purgecoldfiles directive when Cache.EnableLotman is
+// true; xrootd accepts ages only in [1h, 360d]. InitServer must reject
+// out-of-range values before xrootd ever sees them.
+func TestInitServerRejectsLotmanMaxLotLifetimeBelowMinimum(t *testing.T) {
+	ResetConfig()
+	t.Cleanup(func() {
+		ResetConfig()
+	})
+
+	mockFederationRoot(t)
+	setupCacheLotmanPrereqs(t)
+	require.NoError(t, param.Lotman_MaxLotLifetime.Set(30*time.Minute))
+
+	err := InitServer(context.Background(), server_structs.CacheType)
+	require.Error(t, err)
+	require.ErrorContains(t, err, param.Lotman_MaxLotLifetime.GetName())
+	require.ErrorContains(t, err, "1h")
+}
+
+func TestInitServerRejectsLotmanMaxLotLifetimeAboveMaximum(t *testing.T) {
+	ResetConfig()
+	t.Cleanup(func() {
+		ResetConfig()
+	})
+
+	mockFederationRoot(t)
+	setupCacheLotmanPrereqs(t)
+	// 361 days is one day past the 360d ceiling.
+	require.NoError(t, param.Lotman_MaxLotLifetime.Set(361*24*time.Hour))
+
+	err := InitServer(context.Background(), server_structs.CacheType)
+	require.Error(t, err)
+	require.ErrorContains(t, err, param.Lotman_MaxLotLifetime.GetName())
+	require.ErrorContains(t, err, "360d")
+}
+
+func TestInitServerAcceptsLotmanMaxLotLifetimeAtBounds(t *testing.T) {
+	cases := []struct {
+		name string
+		val  time.Duration
+	}{
+		{"min-1h", time.Hour},
+		{"default-168h", 168 * time.Hour},
+		{"max-360d", 360 * 24 * time.Hour},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ResetConfig()
+			t.Cleanup(func() {
+				ResetConfig()
+			})
+
+			mockFederationRoot(t)
+			setupCacheLotmanPrereqs(t)
+			require.NoError(t, param.Lotman_MaxLotLifetime.Set(tc.val))
+
+			// May still fail downstream for unrelated reasons (this is
+			// a cache-type init without xrootd config in place); the
+			// only assertion is that the Lotman boundary check did not
+			// reject the value.
+			err := InitServer(context.Background(), server_structs.CacheType)
+			if err != nil {
+				require.NotContains(t, err.Error(), "exceeds the maximum allowed value")
+				require.NotContains(t, err.Error(), "is below the minimum allowed value")
+			}
+		})
+	}
+}

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -81,8 +81,13 @@ Cache:
   EnableEvictionMonitoring: true
 Lotman:
   EnabledPolicy: "fairshare"
-  DefaultLotExpirationLifetime: "2016h"
-  DefaultLotDeletionLifetime: "4032h"
+  DefaultLotExpirationLifetime: "24h"
+  DefaultLotDeletionLifetime: "48h"
+  MaxLotLifetime: "168h"
+  RenewalCheckInterval: "1h"
+  SchedulingHorizon: "48h"
+  MinFillerWidth: "0"
+  LotRetention: "1440h"
   PolicyDefinitions:
     - PolicyName: "fairshare"
       DivideUnallocated: true

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -86,8 +86,8 @@ Lotman:
   MaxLotLifetime: "168h"
   RenewalCheckInterval: "1h"
   SchedulingHorizon: "48h"
-  MinFillerWidth: "0"
-  LotRetention: "1440h"
+  MinFillerWidth: "0s"
+  LotRecordRetention: "1440h"
   PolicyDefinitions:
     - PolicyName: "fairshare"
       DivideUnallocated: true

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -4537,10 +4537,10 @@ description: |+
   the Pelican CreateLot/UpdateLot wrappers, and the renewal scheduler clamps
   any auto-minted lot's lifetime to this value.
 
-  When Cache.EnableLotman is true, this value is also propagated to the
+  When ${Cache.EnableLotman} is true, this value is also propagated to the
   cache's xrootd configuration as the `purgecoldfiles <age>` argument of
   `pfc.diskusage`. This ensures cached files untouched for longer than
-  Lotman.MaxLotLifetime are evicted by the pfc purge plugin regardless of
+  ${Lotman.MaxLotLifetime} are evicted by the pfc purge plugin regardless of
   the cache's fill level. Without this, the renewal scheduler's continuous
   re-issuance of successor lots over advertised namespace paths would keep
   every cached file associated with a live lot, and watermark-driven
@@ -4558,7 +4558,7 @@ name: Lotman.RenewalCheckInterval
 description: |+
   How often the Lotman renewal scheduler wakes up. On each tick the
   scheduler walks every advertised namespace and ensures lot coverage
-  extends out to Lotman.SchedulingHorizon, minting one or more fresh
+  extends out to ${Lotman.SchedulingHorizon}, minting one or more fresh
   successor lots per path as needed. Smaller values make the system more
   responsive to namespace churn at the cost of more wakeups.
 type: duration
@@ -4569,15 +4569,15 @@ name: Lotman.SchedulingHorizon
 description: |+
   How far into the future the renewal scheduler is willing to mint lots.
   Each tick fills every uncovered region of every advertised namespace
-  inside [now, now+SchedulingHorizon) with back-to-back successor lots.
+  inside [now, now+${Lotman.SchedulingHorizon}) with back-to-back successor lots.
   Lots whose creation_time would fall beyond this horizon are deferred
   to a later tick. Larger values reduce the chance that a missed tick
   produces a coverage lapse, at the cost of a longer wait before a
   newly-discovered namespace receives its fair share of capacity (since
   earlier reservations cannot be contracted).
 
-  Should be ≥ Lotman.DefaultLotExpirationLifetime and ≥
-  Lotman.RenewalCheckInterval. Out-of-range values produce a warning at
+  Should be ≥ ${Lotman.DefaultLotExpirationLifetime} and ≥
+  ${Lotman.RenewalCheckInterval}. Out-of-range values produce a warning at
   startup; the runtime planner additionally clamps the effective
   horizon up to those minima on every tick so a misconfiguration cannot
   cause coverage thrash.
@@ -4591,20 +4591,23 @@ description: |+
   When two existing lots leave a hole shorter than this, the planner
   records a Skip rather than mint a degenerate filler lot. Bytes that
   arrive during such a sub-threshold gap are accounted to the default
-  lot. Set to 0 (the default) to fill every gap regardless of width.
+  lot. Set to 0s (the default) to fill every gap regardless of width.
 type: duration
-default: 0
+default: 0s
 components: ["cache"]
 ---
-name: Lotman.LotRetention
+name: Lotman.LotRecordRetention
 description: |+
   How long a lot's database row is retained after its deletion_time has
   passed. The lot garbage collector removes a lot once
-    now ≥ deletion_time + LotRetention.
+    now ≥ deletion_time + ${Lotman.LotRecordRetention}.
   This gives operators a forensics window during which historical lot
   metadata is still inspectable after the lot's data is gone. A lot is
   assumed to have been reclaimed by the storage layer at or before its
   deletion_time, so this single bound suffices. Default is 60 days.
+  Note: this controls only how long the lot record (database row) is
+  kept; the underlying cached data is removed independently by the
+  xrootd-lotman purge plugin once the lot is past its deletion_time.
 type: duration
 default: 1440h
 components: ["cache"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -4487,8 +4487,8 @@ description: |+
   ```yaml
   Lotman:
     EnabledPolicy: "fairshare"
-    DefaultLotExpirationLifetime: "2016h"
-    DefaultLotDeletionLifetime: "4032h"
+    DefaultLotExpirationLifetime: "24h"
+    DefaultLotDeletionLifetime: "48h"
     PolicyDefinitions:
     - PolicyName: "fairshare"
       DivideUnallocated: true
@@ -4512,7 +4512,7 @@ description: |+
 
   This value is fed to Lotman as a unix timestamp in microseconds, adjusted from the current time.
 type: duration
-default: 2016h
+default: 24h
 components: ["cache"]
 ---
 name: Lotman.DefaultLotDeletionLifetime
@@ -4527,7 +4527,86 @@ description: |+
 
   This value is fed to Lotman as a unix timestamp in microseconds, adjusted from the current time.
 type: duration
-default: 4032h
+default: 48h
+components: ["cache"]
+---
+name: Lotman.MaxLotLifetime
+description: |+
+  The maximum lifetime any lot may have, computed as expiration_time - creation_time.
+  Lots created or updated with a span exceeding this value are rejected by
+  the Pelican CreateLot/UpdateLot wrappers, and the renewal scheduler clamps
+  any auto-minted lot's lifetime to this value.
+
+  When Cache.EnableLotman is true, this value is also propagated to the
+  cache's xrootd configuration as the `purgecoldfiles <age>` argument of
+  `pfc.diskusage`. This ensures cached files untouched for longer than
+  Lotman.MaxLotLifetime are evicted by the pfc purge plugin regardless of
+  the cache's fill level. Without this, the renewal scheduler's continuous
+  re-issuance of successor lots over advertised namespace paths would keep
+  every cached file associated with a live lot, and watermark-driven
+  eviction would never run on a cache that stays below the high watermark.
+
+  Because this value is passed directly to xrootd's `purgecoldfiles`
+  directive, it must fall within the range that xrootd accepts for that
+  directive: [1h, 360d]. Values outside this range are rejected at cache
+  startup with a configuration error.
+type: duration
+default: 168h
+components: ["cache"]
+---
+name: Lotman.RenewalCheckInterval
+description: |+
+  How often the Lotman renewal scheduler wakes up. On each tick the
+  scheduler walks every advertised namespace and ensures lot coverage
+  extends out to Lotman.SchedulingHorizon, minting one or more fresh
+  successor lots per path as needed. Smaller values make the system more
+  responsive to namespace churn at the cost of more wakeups.
+type: duration
+default: 1h
+components: ["cache"]
+---
+name: Lotman.SchedulingHorizon
+description: |+
+  How far into the future the renewal scheduler is willing to mint lots.
+  Each tick fills every uncovered region of every advertised namespace
+  inside [now, now+SchedulingHorizon) with back-to-back successor lots.
+  Lots whose creation_time would fall beyond this horizon are deferred
+  to a later tick. Larger values reduce the chance that a missed tick
+  produces a coverage lapse, at the cost of a longer wait before a
+  newly-discovered namespace receives its fair share of capacity (since
+  earlier reservations cannot be contracted).
+
+  Should be ≥ Lotman.DefaultLotExpirationLifetime and ≥
+  Lotman.RenewalCheckInterval. Out-of-range values produce a warning at
+  startup; the runtime planner additionally clamps the effective
+  horizon up to those minima on every tick so a misconfiguration cannot
+  cause coverage thrash.
+type: duration
+default: 48h
+components: ["cache"]
+---
+name: Lotman.MinFillerWidth
+description: |+
+  Smallest gap the renewal scheduler will bother to fill with a lot.
+  When two existing lots leave a hole shorter than this, the planner
+  records a Skip rather than mint a degenerate filler lot. Bytes that
+  arrive during such a sub-threshold gap are accounted to the default
+  lot. Set to 0 (the default) to fill every gap regardless of width.
+type: duration
+default: 0
+components: ["cache"]
+---
+name: Lotman.LotRetention
+description: |+
+  How long a lot's database row is retained after its deletion_time has
+  passed. The lot garbage collector removes a lot once
+    now ≥ deletion_time + LotRetention.
+  This gives operators a forensics window during which historical lot
+  metadata is still inspectable after the lot's data is gone. A lot is
+  assumed to have been reclaimed by the storage layer at or before its
+  deletion_time, so this single bound suffices. Default is 60 days.
+type: duration
+default: 1440h
 components: ["cache"]
 ---
 name: Topology.DisableDowntime

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/zsais/go-gin-prometheus v0.1.0
 	go.uber.org/atomic v1.11.0
 	golang.org/x/crypto v0.46.0
+	golang.org/x/mod v0.30.0
 	golang.org/x/net v0.48.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/term v0.38.0
@@ -127,7 +128,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.39.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
 	golang.org/x/tools/godoc v0.1.0-deprecated // indirect

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -93,6 +93,15 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 		if success := lotman.InitLotman(cacheServer.GetNamespaceAds()); !success {
 			return nil, errors.New("Failed to initialize lotman")
 		}
+
+		// Background loops:
+		//   - LaunchRenewalRoutine periodically extends per-namespace lot
+		//     coverage so no namespace is left without an active lot.
+		//   - LaunchLotGcRoutine periodically removes lots whose
+		//     deletion_time + Lotman.LotRetention has passed.
+		// Both exit when ctx is done.
+		lotman.LaunchRenewalRoutine(ctx, cacheServer.GetNamespaceAds)
+		lotman.LaunchLotGcRoutine(ctx)
 	}
 
 	// Don't perform Broker operations for site-local caches.

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -98,7 +98,7 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 		//   - LaunchRenewalRoutine periodically extends per-namespace lot
 		//     coverage so no namespace is left without an active lot.
 		//   - LaunchLotGcRoutine periodically removes lots whose
-		//     deletion_time + Lotman.LotRetention has passed.
+		//     deletion_time + Lotman.LotRecordRetention has passed.
 		// Both exit when ctx is done.
 		lotman.LaunchRenewalRoutine(ctx, cacheServer.GetNamespaceAds)
 		lotman.LaunchLotGcRoutine(ctx)

--- a/lotman/epoch.go
+++ b/lotman/epoch.go
@@ -1,0 +1,550 @@
+//go:build linux && !ppc64le
+
+/***************************************************************
+*
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+// Epoch-aware quota allocation.
+//
+// Reservations are immutable once created. To honour the system's
+// "non-contracting" guarantee, the dedicated_GB stamped on a fresh lot
+// must be feasible for the *whole* lifetime of that lot — not merely
+// for the moment it is minted. If we stamped a quota based only on the
+// path-population at minting time, a new sibling appearing later in the
+// lot's lifetime would force an effective contraction (or a violation
+// of axiom 1: sum-of-children's-dedicated ≤ parent's-dedicated).
+//
+// To handle this, the allocator partitions each parent's lifetime into
+// "epochs": maximal half-open intervals during which the set of active
+// children is constant. The boundaries are the union of every active
+// child lot's creation_time and expiration_time within the parent's
+// timeline (and the parent's own creation_time / expiration_time as
+// outer bounds).
+//
+//	parent /a       [────────────────────────────────────)
+//	child  /a/b          [──────────────)
+//	child  /a/c                 [────────────────────)
+//	             ┌────┬─────────┬───────┬────────────┬───┐
+//	epochs       │ E0 │   E1    │  E2   │     E3     │E4 │   (within parent)
+//	active       │    │  /a/b   │ /a/b  │   /a/c     │   │
+//	             │    │         │ /a/c  │            │   │
+//
+// For each epoch, let
+//
+//	usedExisting_e   = Σ existing_sibling.dedicated_GB active in epoch e
+//	residual_e       = parent_dedicated_e − usedExisting_e
+//	nActiveNew_e     = number of OTHER planned-this-tick siblings
+//	                   whose window covers epoch e
+//
+// A freshly-minted child's stamped dedicated_GB then equals
+//
+//	min over epochs the new lot spans of
+//	    residual_e / divisor_e
+//
+// where
+//
+//	divisor_e = nActiveNew_e + 1                  (top level)
+//	divisor_e = nActiveNew_e + 2                  (deeper levels)
+//
+// The "+1" counts the new lot itself; the extra "+1" at deeper levels
+// reserves an equal share for the parent. Existing siblings appear in
+// `usedExisting_e` only — never in `divisor_e` — because their bytes
+// are already committed and counting them again would strand capacity
+// (e.g. root=1000, existing /x at 400, three new top-level paths must
+// each receive (1000−400)/3 = 200, NOT (1000−400)/4 = 150).
+//
+// Choosing the minimum across epochs guarantees axiom 1 holds in every
+// epoch the lot lives in.
+//
+// At the top level the "parent" is the synthetic root lot, whose
+// dedicated_GB is the cache's total storage capacity. The divisor rule
+// above is the same `N` / `N+1` rule used by `lot_tree.go::distribute`,
+// just expressed differently: distribute counts only children
+// (`len(children)` at top, `len(children)+1` deeper), whereas the
+// epoch allocator counts children plus the new lot itself
+// (`nActiveNew+1` at top, `nActiveNew+2` deeper). Both agree on the
+// final per-child share.
+
+package lotman
+
+import (
+	"math"
+	"sort"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// allocateEpochAwareQuotas stamps dedicated_GB (and, when a sane parent
+// figure is available, opportunistic_GB and max_num_objects) on every
+// lot in `prop.NewLots` using min-over-epochs feasibility.
+//
+// `existing` is the set of lots already in the lotman DB at the start
+// of this tick. `cfg.RootDedicatedGB` is the total capacity available
+// to top-level paths.
+//
+// The function never reduces a lot's window — only its quotas. If no
+// feasible non-zero quota exists for a lot in some epoch, that lot is
+// stamped with dedicated_GB=0 (zero-capacity sentinel) and a warning is
+// logged. A zero-capacity lot is a valid lotman record; it just means
+// "no bytes promised here", which lets coverage exist without
+// over-committing storage. Callers may choose to drop such lots; the
+// current behaviour stamps them so the timeline remains continuous.
+func allocateEpochAwareQuotas(prop *RenewalProposal, existing []Lot, fedAds []server_structs.NamespaceAdV2, cfg renewalConfig) {
+	if prop == nil || len(prop.NewLots) == 0 {
+		return
+	}
+	_ = fedAds // reserved for future per-namespace policy overrides
+
+	// Group new lots by namespace path; later we walk them parent-first
+	// so a child sees its parent's already-stamped quotas.
+	newByPath := map[string][]*Lot{}
+	for i := range prop.NewLots {
+		l := &prop.NewLots[i]
+		if len(l.Paths) == 0 {
+			continue
+		}
+		p := normaliseLotPath(l.Paths[0].Path)
+		newByPath[p] = append(newByPath[p], l)
+	}
+
+	paths := make([]string, 0, len(newByPath))
+	for p := range newByPath {
+		paths = append(paths, p)
+	}
+	sort.Slice(paths, func(i, j int) bool {
+		if len(paths[i]) != len(paths[j]) {
+			return len(paths[i]) < len(paths[j])
+		}
+		return paths[i] < paths[j]
+	})
+
+	// `effective` indexes the post-tick view of every namespace path:
+	// existing lots ∪ planned successors. Allocator queries about
+	// "what does the parent look like at instant t?" go here.
+	effective := buildEffectivePathIndex(existing, newByPath)
+
+	for _, p := range paths {
+		parentPath := parentNamespacePath(p, existing, newByPath)
+		for _, lot := range newByPath[p] {
+			ded := computeMinOverEpochsShare(lot, p, parentPath, existing, effective, cfg)
+			if ded < 0 {
+				// computeMinOverEpochsShare returns -1 when no feasible
+				// share exists at all (e.g. parent has no coverage in
+				// some epoch). Stamp zero so the lot exists but
+				// promises nothing.
+				log.Warnf("Lotman allocator: lot %s for %q has no feasible dedicated_GB; stamping 0",
+					lot.LotName, p)
+				ded = 0
+			}
+			v := ded
+			lot.MPA.DedicatedGB = &v
+			// Mirror the share onto parent_attributions so axiom 1 is
+			// satisfied at admission. A self-only attribution is fine
+			// for top-level lots; deeper lots get an explicit parent
+			// attribution under the parent's UUID, but that UUID is
+			// resolved in the apply step. For now, leave attributions
+			// nil (lotman fills them in via recursive aggregation).
+		}
+	}
+}
+
+// computeMinOverEpochsShare returns the largest dedicated_GB the new
+// `lot` can claim while remaining feasible in every epoch its window
+// [creation_time, expiration_time) overlaps. Returns -1 when no
+// feasible share exists at all (e.g. parent has zero coverage in some
+// overlapped epoch).
+func computeMinOverEpochsShare(
+	lot *Lot,
+	path, parentPath string,
+	existing []Lot,
+	effective map[string][]Lot,
+	cfg renewalConfig,
+) float64 {
+	if lot.MPA == nil || lot.MPA.CreationTime == nil || lot.MPA.ExpirationTime == nil {
+		return 0
+	}
+	lotStart := lot.MPA.CreationTime.Value
+	lotEnd := lot.MPA.ExpirationTime.Value
+	if lotEnd <= lotStart {
+		return 0
+	}
+
+	// Index existing lots by lot-name so we can tell, for every entry
+	// in `effective`, whether it came from the pre-tick snapshot
+	// (already stamped, real bytes promised) or from this tick's
+	// freshly-planned proposals (not yet stamped). Real-existing
+	// lots' dedicated_GB is subtracted from `residual`; planned peers
+	// only contribute to the divisor, so the round naturally divides
+	// the parent's free capacity equally even though the for-loop
+	// processes each lot one at a time.
+	existingNames := map[string]struct{}{}
+	for _, l := range existing {
+		existingNames[l.LotName] = struct{}{}
+	}
+
+	// Determine parent's effective timeline (for capacity at each
+	// epoch) and the sibling timelines (the OTHER children sharing
+	// this parent who are active in each epoch).
+	var (
+		parentTimeline []Lot
+		isTopLevel     = parentPath == ""
+		siblingPaths   []string
+	)
+	if isTopLevel {
+		// Top-level path's parent is the synthetic root lot, whose
+		// capacity is constant for all time.
+		siblingPaths = topLevelSiblings(path, effective)
+	} else {
+		parentTimeline = effective[parentPath]
+		siblingPaths = childrenOfParent(parentPath, path, effective)
+	}
+
+	// Sibling epoch boundaries (creation_time / expiration_time of
+	// other lots that share the same parent and overlap [lotStart,
+	// lotEnd)). Plus parent's own boundaries.
+	cuts := []int64{lotStart, lotEnd}
+	for _, s := range siblingPaths {
+		for _, sl := range effective[s] {
+			if sl.MPA == nil || sl.MPA.CreationTime == nil || sl.MPA.ExpirationTime == nil {
+				continue
+			}
+			c := sl.MPA.CreationTime.Value
+			e := sl.MPA.ExpirationTime.Value
+			if c < lotStart {
+				c = lotStart
+			}
+			if e > lotEnd {
+				e = lotEnd
+			}
+			if c < e {
+				cuts = append(cuts, c, e)
+			}
+		}
+	}
+	if !isTopLevel {
+		for _, pl := range parentTimeline {
+			if pl.MPA == nil || pl.MPA.CreationTime == nil || pl.MPA.ExpirationTime == nil {
+				continue
+			}
+			c := pl.MPA.CreationTime.Value
+			e := pl.MPA.ExpirationTime.Value
+			if c < lotStart {
+				c = lotStart
+			}
+			if e > lotEnd {
+				e = lotEnd
+			}
+			if c < e {
+				cuts = append(cuts, c, e)
+			}
+		}
+	}
+	cuts = uniqueSortedInt64(cuts)
+
+	// Iterate adjacent cut pairs; each pair is one epoch [a, b).
+	minShare := math.Inf(+1)
+	for i := 0; i+1 < len(cuts); i++ {
+		a, b := cuts[i], cuts[i+1]
+		if a < lotStart {
+			a = lotStart
+		}
+		if b > lotEnd {
+			b = lotEnd
+		}
+		if b <= a {
+			continue
+		}
+		mid := a + (b-a)/2 // representative instant inside [a, b)
+
+		// Parent capacity at mid.
+		var parentCap float64
+		if isTopLevel {
+			parentCap = cfg.RootDedicatedGB
+			if parentCap <= 0 {
+				// Without a known root capacity we can't compute a
+				// non-contracting share. Stamp 0; the operator sees
+				// the warning at the call site.
+				return 0
+			}
+		} else {
+			seg := parentSegmentAt(parentTimeline, mid)
+			if !seg.ok {
+				// Parent has no coverage at this instant — should
+				// have been excluded by the planner's clamp, but
+				// be defensive.
+				return -1
+			}
+			pc, ok := dedicatedAt(parentTimeline, mid)
+			if !ok || pc <= 0 {
+				return -1
+			}
+			parentCap = pc
+		}
+
+		// Sum of OTHER children's dedicated_GB at mid that come from
+		// the existing snapshot (already-promised bytes), and a
+		// separate count of how many distinct sibling paths have a
+		// PLANNED-this-tick lot active at mid. Existing siblings are
+		// excluded from the divisor: their bytes have already been
+		// subtracted from `parentCap` via `usedExisting`, so counting
+		// them again as a divisor slot would double-count them and
+		// leave a chunk of capacity unbookable. (Example: root=1000,
+		// existing /x at 400, three new /a /b /c — the residual 600
+		// must be split among the 3 newcomers, giving 200 each. Adding
+		// /x to the divisor would give 600/4=150 each and leave 150
+		// stranded.)
+		usedExisting := 0.0
+		nActiveNew := 0
+		for _, s := range siblingPaths {
+			plannedActive := false
+			for _, sl := range effective[s] {
+				if sl.MPA == nil || sl.MPA.CreationTime == nil || sl.MPA.ExpirationTime == nil {
+					continue
+				}
+				if sl.MPA.CreationTime.Value <= mid && mid < sl.MPA.ExpirationTime.Value {
+					if _, isExisting := existingNames[sl.LotName]; isExisting {
+						if sl.MPA.DedicatedGB != nil {
+							usedExisting += *sl.MPA.DedicatedGB
+						}
+					} else {
+						plannedActive = true
+					}
+				}
+			}
+			if plannedActive {
+				nActiveNew++
+			}
+		}
+		residual := parentCap - usedExisting
+		if residual <= 0 {
+			// No room left in this epoch.
+			return -1
+		}
+
+		// Divisor: at the top level the new lot competes only against
+		// other newcomers (no parent reserve), so divisor = N+1 (self).
+		// At deeper levels the parent keeps an equal share as a
+		// reserve, so divisor = N+2 — matching the rule already
+		// enforced by lot_tree.go::distribute (parent.distribute uses
+		// len(children) at top, len(children)+1 deeper).
+		divisor := nActiveNew + 1 // include this lot itself
+		if !isTopLevel {
+			divisor++
+		}
+		if divisor <= 0 {
+			continue
+		}
+		share := residual / float64(divisor)
+		if share < minShare {
+			minShare = share
+		}
+	}
+
+	if math.IsInf(minShare, +1) {
+		// No epochs were considered (e.g. zero-width lot). Treat as 0.
+		return 0
+	}
+	if minShare < 0 {
+		return 0
+	}
+	return minShare
+}
+
+// dedicatedAt returns the dedicated_GB of the lot in `timeline` covering
+// `instantMs`, or (0, false) when no lot covers that instant. Lots
+// without an explicit dedicated_GB are treated as `parent inheritance`
+// for which we conservatively assume 0 contribution to `used`; that may
+// under-count usage in mixed populations of stamped + nil-quota lots,
+// but the planner stamps explicit values on every renewal so steady
+// state has no nil entries.
+func dedicatedAt(timeline []Lot, instantMs int64) (float64, bool) {
+	for _, l := range timeline {
+		if l.MPA == nil || l.MPA.CreationTime == nil || l.MPA.ExpirationTime == nil {
+			continue
+		}
+		if l.MPA.CreationTime.Value <= instantMs && instantMs < l.MPA.ExpirationTime.Value {
+			if l.MPA.DedicatedGB == nil {
+				return 0, true
+			}
+			return *l.MPA.DedicatedGB, true
+		}
+	}
+	return 0, false
+}
+
+// buildEffectivePathIndex returns a map[path] -> sorted timeline of
+// lots, where each timeline is the union of existing lots whose
+// paths[0].Path equals path and any planned successors for that path.
+// Used by the allocator to query the post-tick world.
+//
+// Path-canonicalisation invariant: throughout the renewal scheduler
+// (renewal.go, epoch.go), a lot is identified by `paths[0].Path`. This
+// matches how Pelican mints lots — a single namespace ad produces a
+// single-path lot — and is consistent with `lotsForNamespace` (which
+// scans every entry in `paths` for backwards compatibility). Operators
+// who hand-create multi-path lots may see those extra paths ignored by
+// the allocator; the renewal scheduler currently does not mint
+// multi-path lots itself.
+func buildEffectivePathIndex(existing []Lot, planned map[string][]*Lot) map[string][]Lot {
+	out := map[string][]Lot{}
+	for _, l := range existing {
+		if len(l.Paths) == 0 {
+			continue
+		}
+		p := normaliseLotPath(l.Paths[0].Path)
+		out[p] = append(out[p], l)
+	}
+	for p, lots := range planned {
+		for _, l := range lots {
+			if l == nil {
+				continue
+			}
+			out[normaliseLotPath(p)] = append(out[normaliseLotPath(p)], *l)
+		}
+	}
+	for _, lots := range out {
+		sort.Slice(lots, func(i, j int) bool {
+			ci := int64(0)
+			cj := int64(0)
+			if lots[i].MPA != nil && lots[i].MPA.CreationTime != nil {
+				ci = lots[i].MPA.CreationTime.Value
+			}
+			if lots[j].MPA != nil && lots[j].MPA.CreationTime != nil {
+				cj = lots[j].MPA.CreationTime.Value
+			}
+			return ci < cj
+		})
+		// sort.Slice mutates the slice header's underlying array in
+		// place; the map entry already points at the sorted backing
+		// storage, so no `out[p] = lots` reassignment is needed.
+	}
+	return out
+}
+
+// topLevelSiblings returns every path in `effective` that is at the top
+// level (i.e. no other path in `effective` is its strict ancestor),
+// excluding `self`. Used by the allocator to know who else is competing
+// for root's pool.
+func topLevelSiblings(self string, effective map[string][]Lot) []string {
+	target := normaliseLotPath(self)
+	out := make([]string, 0, len(effective))
+	for p := range effective {
+		c := normaliseLotPath(p)
+		if c == "" || c == target {
+			continue
+		}
+		// Skip synthetic root/default lot entries that may sneak in via
+		// the existing snapshot but have no namespace path.
+		if c == "/" {
+			continue
+		}
+		isTop := true
+		for q := range effective {
+			d := normaliseLotPath(q)
+			if d == c || d == "" {
+				continue
+			}
+			if pathContains(d, c) {
+				isTop = false
+				break
+			}
+		}
+		if isTop {
+			out = append(out, c)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// childrenOfParent returns every path in `effective` whose direct
+// parent (longest-prefix ancestor present in `effective`) is `parent`,
+// excluding `self`.
+func childrenOfParent(parent, self string, effective map[string][]Lot) []string {
+	parentN := normaliseLotPath(parent)
+	selfN := normaliseLotPath(self)
+	out := make([]string, 0, len(effective))
+	for p := range effective {
+		c := normaliseLotPath(p)
+		if c == "" || c == selfN || c == parentN {
+			continue
+		}
+		// `c` is a child of `parent` iff `parent` is c's
+		// longest-prefix ancestor in `effective`.
+		if !pathContains(parentN, c) {
+			continue
+		}
+		// Verify nothing strictly between parent and c also lives in
+		// effective (which would make that intermediate the real
+		// parent, not `parent`).
+		isDirect := true
+		for q := range effective {
+			d := normaliseLotPath(q)
+			if d == c || d == parentN || d == "" {
+				continue
+			}
+			if pathContains(parentN, d) && pathContains(d, c) && len(d) > len(parentN) {
+				isDirect = false
+				break
+			}
+		}
+		if isDirect {
+			out = append(out, c)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// uniqueSortedInt64 returns a stable, ascending, deduplicated copy of `xs`.
+func uniqueSortedInt64(xs []int64) []int64 {
+	if len(xs) == 0 {
+		return xs
+	}
+	cp := make([]int64, len(xs))
+	copy(cp, xs)
+	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
+	w := 0
+	for i := 0; i < len(cp); i++ {
+		if w == 0 || cp[w-1] != cp[i] {
+			cp[w] = cp[i]
+			w++
+		}
+	}
+	return cp[:w]
+}
+
+// rootDedicatedGB returns the total capacity available at the top of
+// the lot tree. We look it up from the existing snapshot rather than
+// recomputing disk capacity: lotman's "root" lot is created at startup
+// with the right value (see computeRootDedicatedGB) and is non-expiring.
+// Returns 0 when no root lot exists or its dedicated_GB is unset; the
+// allocator then stamps zero quotas on top-level lots and warns.
+func rootDedicatedGB(existing []Lot) float64 {
+	for _, l := range existing {
+		if l.LotName != "root" {
+			continue
+		}
+		if l.MPA == nil || l.MPA.DedicatedGB == nil {
+			return 0
+		}
+		return *l.MPA.DedicatedGB
+	}
+	return 0
+}

--- a/lotman/epoch.go
+++ b/lotman/epoch.go
@@ -90,9 +90,18 @@ import (
 	"github.com/pelicanplatform/pelican/server_structs"
 )
 
-// allocateEpochAwareQuotas stamps dedicated_GB (and, when a sane parent
-// figure is available, opportunistic_GB and max_num_objects) on every
-// lot in `prop.NewLots` using min-over-epochs feasibility.
+// allocateEpochAwareQuotas stamps dedicated_GB on every lot in
+// `prop.newLots` using min-over-epochs feasibility.
+//
+// max_num_objects and opportunistic_GB are pre-stamped to the
+// unbounded sentinel (-1) by renewExpiringLots itself: lotman's
+// new_lot_schema requires both fields to be present on every
+// CreateLot call, so we cannot leave them nil even though
+// pelican+xrootd-lotman does not currently consume either axis. Using
+// -1 (unbounded) keeps lots schema-valid without imposing a real cap;
+// once the xrootd-lotman purge plugin learns to honour either field,
+// the allocator can overwrite these defaults from the same
+// min-over-epochs analysis used for dedicated_GB.
 //
 // `existing` is the set of lots already in the lotman DB at the start
 // of this tick. `cfg.RootDedicatedGB` is the total capacity available
@@ -101,21 +110,29 @@ import (
 // The function never reduces a lot's window — only its quotas. If no
 // feasible non-zero quota exists for a lot in some epoch, that lot is
 // stamped with dedicated_GB=0 (zero-capacity sentinel) and a warning is
-// logged. A zero-capacity lot is a valid lotman record; it just means
-// "no bytes promised here", which lets coverage exist without
-// over-committing storage. Callers may choose to drop such lots; the
-// current behaviour stamps them so the timeline remains continuous.
-func allocateEpochAwareQuotas(prop *RenewalProposal, existing []Lot, fedAds []server_structs.NamespaceAdV2, cfg renewalConfig) {
-	if prop == nil || len(prop.NewLots) == 0 {
+// logged. A zero-capacity lot is a valid lotman record; it carries no
+// dedicated promise but still defines a paths/owner/window for
+// accounting and lets the timeline stay continuous, which lot_tree.go
+// relies on for hierarchy invariants. The data attributed to such a
+// lot is accounted to the default lot at purge time. Operators may
+// alert on the warning above and re-tune quotas; the alternative —
+// silently dropping the lot — would create a coverage gap that the
+// next tick would just refill.
+func allocateEpochAwareQuotas(prop *renewalProposal, existing []Lot, fedAds []server_structs.NamespaceAdV2, cfg renewalConfig) {
+	if prop == nil || len(prop.newLots) == 0 {
 		return
 	}
-	_ = fedAds // reserved for future per-namespace policy overrides
+	_ = fedAds // reserved for future per-namespace overrides; once the
+	// director starts populating lot-policy fields on
+	// server_structs.NamespaceAdV2, this allocator will read them here
+	// to override defaults like the (N+1)/(N+2) divisor or per-NS
+	// dedicated/opportunistic ratios.
 
 	// Group new lots by namespace path; later we walk them parent-first
 	// so a child sees its parent's already-stamped quotas.
 	newByPath := map[string][]*Lot{}
-	for i := range prop.NewLots {
-		l := &prop.NewLots[i]
+	for i := range prop.newLots {
+		l := &prop.newLots[i]
 		if len(l.Paths) == 0 {
 			continue
 		}

--- a/lotman/integration_test.go
+++ b/lotman/integration_test.go
@@ -1,0 +1,181 @@
+//go:build linux && !ppc64le && lotman
+
+/***************************************************************
+*
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package lotman
+
+import (
+	"net/url"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// TestRenewalEndToEnd is a federation-light integration test: it boots a
+// real lotman instance via setupLotmanFromConf, registers two namespace
+// ads (parent /foo and child /foo/bar), and exercises the full
+// renewal → renewal → GC pipeline through runRenewalTick / runGcTick
+// rather than calling the pure planner helpers directly.
+//
+// Coverage targets:
+//  1. The first tick mints lots for both ads with the expected
+//     parent/child relationship.
+//  2. A second tick after the lots have moved deeper into their
+//     lifetime is a no-op (existing coverage already extends to the
+//     scheduling horizon).
+//  3. After deletion_time + LotRecordRetention has elapsed, runGcTick
+//     removes the now-eligible lots while leaving root/default
+//     intact.
+//
+// The test uses tiny per-call durations (seconds, not hours) so it
+// completes in well under a second.
+func TestRenewalEndToEnd(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+
+	server := getMockDiscoveryHost()
+	defer server.Close()
+	require.NoError(t, param.Federation_DiscoveryUrl.Set(server.URL))
+
+	success, cleanup := setupLotmanFromConf(t, false, "LotmanRenewalE2E", server.URL, nil)
+	defer cleanup()
+	require.True(t, success, "InitLotman must succeed")
+
+	// Tight timings so the GC eligibility window opens within the
+	// test's wall-clock lifetime. Set AFTER setupLotmanFromConf because
+	// that helper resets the lifetime durations to 168h to keep
+	// non-renewal tests from racing the planner.
+	require.NoError(t, param.Lotman_DefaultLotExpirationLifetime.Set(2*time.Second))
+	require.NoError(t, param.Lotman_DefaultLotDeletionLifetime.Set(2*time.Second))
+	require.NoError(t, param.Lotman_MaxLotLifetime.Set(10*time.Second))
+	require.NoError(t, param.Lotman_SchedulingHorizon.Set(2*time.Second))
+	require.NoError(t, param.Lotman_RenewalCheckInterval.Set(1*time.Second))
+	require.NoError(t, param.Lotman_LotRecordRetention.Set(100*time.Millisecond))
+	require.NoError(t, param.Lotman_MinFillerWidth.Set(0))
+
+	issuerURL, _ := url.Parse("https://issuer.example/")
+	ads := []server_structs.NamespaceAdV2{
+		{Path: "/foo", Issuer: []server_structs.TokenIssuer{{IssuerUrl: *issuerURL}}},
+		{Path: "/foo/bar", Issuer: []server_structs.TokenIssuer{{IssuerUrl: *issuerURL}}},
+	}
+	getAds := func() []server_structs.NamespaceAdV2 { return ads }
+
+	// --- Tick 1: should mint lots for /foo and /foo/bar -----------------
+	runRenewalTick(getAds, time.Second)
+
+	all, err := ListAllLots()
+	require.NoError(t, err)
+	sort.Strings(all)
+	// root + default are auto-created; we expect at least two more (one
+	// per namespace ad, sometimes a few more depending on filler logic).
+	mintedFoo := lotsCoveringPath(t, "/foo", all)
+	mintedFooBar := lotsCoveringPath(t, "/foo/bar", all)
+	require.NotEmpty(t, mintedFoo, "tick should mint at least one /foo lot")
+	require.NotEmpty(t, mintedFooBar, "tick should mint at least one /foo/bar lot")
+
+	// Parent of /foo/bar successor should be the freshly-planned /foo
+	// successor (not root). Pull each /foo/bar lot back and assert.
+	for _, name := range mintedFooBar {
+		lot, err := GetLot(name, false)
+		require.NoError(t, err)
+		require.NotEmpty(t, lot.Parents, "/foo/bar lot %s must have a parent", name)
+		// Parent must be one of the /foo lots (not root/default).
+		parent := lot.Parents[0]
+		assert.Contains(t, mintedFoo, parent,
+			"child /foo/bar lot %s should chain to a /foo lot, got %s", name, parent)
+	}
+
+	// --- Tick 2: same horizon, run immediately. The planner is a
+	// multi-fill scheduler, so it may legitimately extend coverage by
+	// minting one more successor when the previous tick's lots only
+	// reach the horizon boundary. We only assert it does not delete
+	// the lots from tick 1.
+	beforeNames := map[string]struct{}{}
+	for _, n := range all {
+		beforeNames[n] = struct{}{}
+	}
+	runRenewalTick(getAds, time.Second)
+	allAfter, err := ListAllLots()
+	require.NoError(t, err)
+	for n := range beforeNames {
+		assert.Contains(t, allAfter, n,
+			"second tick must not remove lot %s minted by first tick", n)
+	}
+
+	// --- GC eligibility: shrink horizon out so new lots aren't minted,
+	//     wait past deletion_time + LotRecordRetention, then GC --------
+	// 2s expiration + 2s deletion + 100ms retention ≈ 4.2s after tick 1.
+	// We sleep 5s to be safe.
+	time.Sleep(5 * time.Second)
+
+	// Stop the renewal scheduler from minting fresh lots during GC by
+	// supplying an empty ad list.
+	emptyAds := func() []server_structs.NamespaceAdV2 { return nil }
+	runRenewalTick(emptyAds, time.Second)
+
+	runGcTick()
+	allFinal, err := ListAllLots()
+	require.NoError(t, err)
+	// root and default must survive; planner-minted lots should be gone.
+	hasRoot := false
+	hasDefault := false
+	plannerLeft := 0
+	for _, n := range allFinal {
+		switch n {
+		case "root":
+			hasRoot = true
+		case "default":
+			hasDefault = true
+		default:
+			plannerLeft++
+		}
+	}
+	assert.True(t, hasRoot, "root lot must survive GC")
+	assert.True(t, hasDefault, "default lot must survive GC")
+	assert.Zero(t, plannerLeft,
+		"all planner-minted lots should be GC'd once past deletion_time + LotRecordRetention; %d still present (%v)",
+		plannerLeft, allFinal)
+}
+
+// lotsCoveringPath returns the names from `all` whose paths[0].Path equals
+// the supplied namespace path.
+func lotsCoveringPath(t *testing.T, path string, all []string) []string {
+	t.Helper()
+	out := []string{}
+	for _, name := range all {
+		if name == "root" || name == "default" {
+			continue
+		}
+		lot, err := GetLot(name, false)
+		require.NoError(t, err)
+		for _, lp := range lot.Paths {
+			if normaliseLotPath(lp.Path) == normaliseLotPath(path) {
+				out = append(out, name)
+				break
+			}
+		}
+	}
+	return out
+}

--- a/lotman/lot_tree.go
+++ b/lotman/lot_tree.go
@@ -79,6 +79,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
 )
@@ -186,9 +188,15 @@ func buildLotTree(rootLot Lot, nsAds []server_structs.NamespaceAdV2, federationI
 			}
 		}
 
+		// Lot names are now opaque UUIDs (rather than the namespace path).
+		// The human-readable namespace path lives only on `paths[].Path`,
+		// which lotman uses for its longest-prefix path resolution. Decoupling
+		// the lot name from its path lets us mint a fresh successor lot when
+		// renewing without colliding with the still-live predecessor that
+		// owns the same path during the overlap window.
 		node := &lotTreeNode{
 			lot: Lot{
-				LotName: ns.path,
+				LotName: uuid.NewString(),
 				Owner:   ns.issuer,
 				Parents: []string{parent.lot.LotName},
 				Paths: []LotPath{{
@@ -362,8 +370,10 @@ func flattenTreeForCreation(root *lotTreeNode) []Lot {
 	walk = func(n *lotTreeNode) {
 		out = append(out, n.lot)
 		// Stable child ordering helps tests and reproducible logs.
+		// Sort by primary path (paths[0].Path) when present, falling back
+		// to LotName so root and lots without paths keep deterministic order.
 		sort.Slice(n.children, func(i, j int) bool {
-			return n.children[i].lot.LotName < n.children[j].lot.LotName
+			return childSortKey(n.children[i]) < childSortKey(n.children[j])
 		})
 		for _, c := range n.children {
 			walk(c)
@@ -371,4 +381,42 @@ func flattenTreeForCreation(root *lotTreeNode) []Lot {
 	}
 	walk(root)
 	return out
+}
+
+// childSortKey returns the sort key for sibling ordering. Namespace lots
+// have their first declared path; root/default and other path-less lots
+// fall through to their LotName (a UUID for namespace lots, fixed for root).
+func childSortKey(n *lotTreeNode) string {
+	if len(n.lot.Paths) > 0 {
+		return n.lot.Paths[0].Path
+	}
+	return n.lot.LotName
+}
+
+// findLotNodeByPath walks the tree depth-first and returns the first node
+// whose paths[0].Path matches the supplied namespace path. Used by tests
+// (and renewal) to find the UUID-named lot for a known namespace.
+func findLotNodeByPath(root *lotTreeNode, nsPath string) *lotTreeNode {
+	if root == nil {
+		return nil
+	}
+	nsPath = normaliseLotPath(nsPath)
+	var walk func(n *lotTreeNode) *lotTreeNode
+	walk = func(n *lotTreeNode) *lotTreeNode {
+		if n == nil {
+			return nil
+		}
+		for _, p := range n.lot.Paths {
+			if normaliseLotPath(p.Path) == nsPath {
+				return n
+			}
+		}
+		for _, c := range n.children {
+			if found := walk(c); found != nil {
+				return found
+			}
+		}
+		return nil
+	}
+	return walk(root)
 }

--- a/lotman/lot_tree_test.go
+++ b/lotman/lot_tree_test.go
@@ -66,22 +66,26 @@ func rootSeed(dedGB float64) Lot {
 	}
 }
 
-// childByName looks up a node anywhere in the tree by its lot name.
-// Used by table tests to assert per-node quotas without depending on
-// child ordering.
-func childByName(root *lotTreeNode, name string) *lotTreeNode {
-	if root == nil {
-		return nil
+// childByPath looks up a tree node by its first declared namespace path.
+// This is the canonical lookup for namespace lots since their LotName is
+// a UUID. Returns nil if no node has nsPath in its paths[].
+func childByPath(root *lotTreeNode, nsPath string) *lotTreeNode {
+	return findLotNodeByPath(root, nsPath)
+}
+
+// parentNameMatches returns true when the supplied parent-name (recorded
+// in node.lot.Parents[0]) refers to either the literal "root" lot, or to
+// the lot returned by childByPath(root, expected). This indirection is
+// required because non-root namespace lots now have UUID names.
+func parentNameMatches(root *lotTreeNode, parentName, expected string) bool {
+	if expected == "root" {
+		return parentName == "root"
 	}
-	if root.lot.LotName == name {
-		return root
+	node := childByPath(root, expected)
+	if node == nil {
+		return false
 	}
-	for _, c := range root.children {
-		if found := childByName(c, name); found != nil {
-			return found
-		}
-	}
-	return nil
+	return node.lot.LotName == parentName
 }
 
 func TestPathContains(t *testing.T) {
@@ -90,9 +94,9 @@ func TestPathContains(t *testing.T) {
 		want          bool
 	}{
 		{"/foo", "/foo/bar", true},
-		{"/foo", "/foobar", false},        // segment-boundary check
-		{"/foo", "/foo", false},           // strict ancestor
-		{"/", "/anything", true},          // root contains everything
+		{"/foo", "/foobar", false}, // segment-boundary check
+		{"/foo", "/foo", false},    // strict ancestor
+		{"/", "/anything", true},   // root contains everything
 		{"/foo/bar", "/foo/bar/baz", true},
 		{"/foo/bar", "/foo/bar2", false},
 	}
@@ -178,16 +182,17 @@ func TestBuildLotTree_PathContainment(t *testing.T) {
 			tree := buildLotTree(rootSeed(100), makeAds(c.paths...), "https://fed.example/")
 			require.NotNil(t, tree)
 			for childPath, parentName := range c.expectParent {
-				node := childByName(tree, childPath)
-				require.NotNilf(t, node, "expected node %q to exist", childPath)
+				node := childByPath(tree, childPath)
+				require.NotNilf(t, node, "expected node for path %q to exist", childPath)
 				require.Lenf(t, node.lot.Parents, 1, "node %q should have exactly one parent", childPath)
-				assert.Equalf(t, parentName, node.lot.Parents[0],
-					"node %q parent mismatch", childPath)
+				assert.Truef(t, parentNameMatches(tree, node.lot.Parents[0], parentName),
+					"node %q parent mismatch: got %q, expected lot at path %q",
+					childPath, node.lot.Parents[0], parentName)
 			}
 			// Negative: monitoring path should never appear in tree.
 			for _, p := range c.paths {
 				if p == "/pelican/monitoring/probe" {
-					assert.Nil(t, childByName(tree, "/pelican/monitoring/probe"))
+					assert.Nil(t, childByPath(tree, "/pelican/monitoring/probe"))
 				}
 			}
 		})
@@ -199,8 +204,8 @@ func TestAllocateQuotas_TopLevel(t *testing.T) {
 	tree := buildLotTree(rootSeed(6), makeAds("/foo", "/bar"), "https://fed.example/")
 	allocateQuotas(tree)
 
-	foo := childByName(tree, "/foo")
-	bar := childByName(tree, "/bar")
+	foo := childByPath(tree, "/foo")
+	bar := childByPath(tree, "/bar")
 	require.NotNil(t, foo)
 	require.NotNil(t, bar)
 	assert.InDelta(t, 3.0, *foo.lot.MPA.DedicatedGB, 1e-9)
@@ -228,9 +233,9 @@ func TestAllocateQuotas_NPlusOneRule(t *testing.T) {
 		makeAds("/foo", "/foo/bar", "/foo/baz"), "https://fed.example/")
 	allocateQuotas(tree)
 
-	foo := childByName(tree, "/foo")
-	bar := childByName(tree, "/foo/bar")
-	baz := childByName(tree, "/foo/baz")
+	foo := childByPath(tree, "/foo")
+	bar := childByPath(tree, "/foo/bar")
+	baz := childByPath(tree, "/foo/baz")
 	require.NotNil(t, foo)
 	require.NotNil(t, bar)
 	require.NotNil(t, baz)
@@ -245,10 +250,10 @@ func TestAllocateQuotas_NPlusOneRule(t *testing.T) {
 
 	// Sum of grandchildren's attribution to /foo = 6 < 9 (axiom 1 satisfied
 	// with room to spare, which is the (N+1) rule's purpose).
-	require.Contains(t, bar.lot.ParentAttributions, "/foo")
-	require.Contains(t, baz.lot.ParentAttributions, "/foo")
-	assert.InDelta(t, 3.0, *bar.lot.ParentAttributions["/foo"].DedicatedGB, 1e-9)
-	assert.InDelta(t, 3.0, *baz.lot.ParentAttributions["/foo"].DedicatedGB, 1e-9)
+	require.Contains(t, bar.lot.ParentAttributions, foo.lot.LotName)
+	require.Contains(t, baz.lot.ParentAttributions, foo.lot.LotName)
+	assert.InDelta(t, 3.0, *bar.lot.ParentAttributions[foo.lot.LotName].DedicatedGB, 1e-9)
+	assert.InDelta(t, 3.0, *baz.lot.ParentAttributions[foo.lot.LotName].DedicatedGB, 1e-9)
 }
 
 func TestAllocateQuotas_AxiomOneSatisfied(t *testing.T) {
@@ -295,12 +300,16 @@ func TestFlattenTreeForCreation_PreOrder(t *testing.T) {
 	allocateQuotas(tree)
 	flat := flattenTreeForCreation(tree)
 
-	// Build a name -> position map and assert every parent precedes its
-	// children. This is the only contract downstream lotman_add_lot relies
-	// on.
+	// Build a path -> position map (lot names are now UUIDs, so we key on
+	// the namespace path stored in paths[0].Path). Root has no path entries
+	// and keeps its literal name. Assert every parent precedes its children.
 	pos := map[string]int{}
 	for i, lot := range flat {
-		pos[lot.LotName] = i
+		key := lot.LotName
+		if len(lot.Paths) > 0 {
+			key = lot.Paths[0].Path
+		}
+		pos[key] = i
 	}
 	require.Contains(t, pos, "root")
 	require.Contains(t, pos, "/a")

--- a/lotman/lotman.go
+++ b/lotman/lotman.go
@@ -77,28 +77,29 @@ func GetPolicyMap() (map[string]PurgePolicy, error) {
 // The following stubs mirror the high-level wrappers added in
 // lotman_linux.go so callers compile on non-Linux platforms.
 
-func IsRoot(string) (bool, error)                                          { return false, errUnsupported }
-func LotExists(string) (bool, error)                                       { return false, errUnsupported }
-func ListAllLots() ([]string, error)                                       { return nil, errUnsupported }
-func GetChildrenNames(string, bool, bool) ([]string, error)                { return nil, errUnsupported }
-func GetParentNames(string, bool, bool) ([]string, error)                  { return nil, errUnsupported }
-func GetOwners(string, bool) ([]string, error)                             { return nil, errUnsupported }
-func GetLotsFromDir(string, bool, int64) ([]string, error)                 { return nil, errUnsupported }
-func GetLotsPastExp(bool, bool) ([]string, error)                          { return nil, errUnsupported }
-func GetLotsPastDel(bool, bool) ([]string, error)                          { return nil, errUnsupported }
-func GetLotsPastDed(bool, bool, bool, bool) ([]string, error)              { return nil, errUnsupported }
-func GetLotsPastOpp(bool, bool, bool, bool) ([]string, error)              { return nil, errUnsupported }
-func GetLotsPastObj(bool, bool, bool, bool) ([]string, error)              { return nil, errUnsupported }
-func ReclaimLot(string, int64, string, string) (int, error)                { return 0, errUnsupported }
-func UpdateLotUsage(string, bool, string) error                            { return errUnsupported }
-func UpdateLotUsageByDir(string, bool, int64, string) error                { return errUnsupported }
-func GetPolicyAttributes(PolicyAttrsRequest) (*RestrictiveMPA, error)      { return nil, errUnsupported }
-func GetLotDirs(string, bool) ([]LotPath, error)                           { return nil, errUnsupported }
-func GetLotUsage(UsageRequest) (*LotUsage, error)                          { return nil, errUnsupported }
+func IsRoot(string) (bool, error)                                     { return false, errUnsupported }
+func LotExists(string) (bool, error)                                  { return false, errUnsupported }
+func ListAllLots() ([]string, error)                                  { return nil, errUnsupported }
+func GetChildrenNames(string, bool, bool) ([]string, error)           { return nil, errUnsupported }
+func GetParentNames(string, bool, bool) ([]string, error)             { return nil, errUnsupported }
+func GetOwners(string, bool) ([]string, error)                        { return nil, errUnsupported }
+func GetLotsFromDir(string, bool, int64) ([]string, error)            { return nil, errUnsupported }
+func GetLotsForPath(string, bool, int64, int64, bool) ([]Lot, error)  { return nil, errUnsupported }
+func GetLotsPastExp(int64, bool, bool) ([]string, error)              { return nil, errUnsupported }
+func GetLotsPastDel(int64, bool, bool) ([]string, error)              { return nil, errUnsupported }
+func GetLotsPastDed(bool, bool, bool, bool) ([]string, error)         { return nil, errUnsupported }
+func GetLotsPastOpp(bool, bool, bool, bool) ([]string, error)         { return nil, errUnsupported }
+func GetLotsPastObj(bool, bool, bool, bool) ([]string, error)         { return nil, errUnsupported }
+func ReclaimLot(string, int64, string, string) (int, error)           { return 0, errUnsupported }
+func UpdateLotUsage(string, bool, string) error                       { return errUnsupported }
+func UpdateLotUsageByDir(string, bool, int64, string) error           { return errUnsupported }
+func GetPolicyAttributes(PolicyAttrsRequest) (*RestrictiveMPA, error) { return nil, errUnsupported }
+func GetLotDirs(string, bool) ([]LotPath, error)                      { return nil, errUnsupported }
+func GetLotUsage(UsageRequest) (*LotUsage, error)                     { return nil, errUnsupported }
 func GetAvailableCapacity(string, int64, int64) (*AvailableCapacity, error) {
 	return nil, errUnsupported
 }
-func SetContextInt(string, int) error  { return errUnsupported }
+func SetContextInt(string, int) error   { return errUnsupported }
 func GetContextInt(string) (int, error) { return 0, errUnsupported }
 func RemoveLot(string, bool, bool, bool, bool, string) error {
 	return errUnsupported

--- a/lotman/lotman.go
+++ b/lotman/lotman.go
@@ -84,11 +84,14 @@ func GetChildrenNames(string, bool, bool) ([]string, error)                { ret
 func GetParentNames(string, bool, bool) ([]string, error)                  { return nil, errUnsupported }
 func GetOwners(string, bool) ([]string, error)                             { return nil, errUnsupported }
 func GetLotsFromDir(string, bool, int64) ([]string, error)                 { return nil, errUnsupported }
-func GetLotsPastExp(bool) ([]string, error)                                { return nil, errUnsupported }
-func GetLotsPastDel(bool) ([]string, error)                                { return nil, errUnsupported }
-func GetLotsPastDed(bool, bool, bool) ([]string, error)                    { return nil, errUnsupported }
-func GetLotsPastOpp(bool, bool, bool) ([]string, error)                    { return nil, errUnsupported }
-func GetLotsPastObj(bool, bool, bool) ([]string, error)                    { return nil, errUnsupported }
+func GetLotsPastExp(bool, bool) ([]string, error)                          { return nil, errUnsupported }
+func GetLotsPastDel(bool, bool) ([]string, error)                          { return nil, errUnsupported }
+func GetLotsPastDed(bool, bool, bool, bool) ([]string, error)              { return nil, errUnsupported }
+func GetLotsPastOpp(bool, bool, bool, bool) ([]string, error)              { return nil, errUnsupported }
+func GetLotsPastObj(bool, bool, bool, bool) ([]string, error)              { return nil, errUnsupported }
+func ReclaimLot(string, int64, string, string) (int, error)                { return 0, errUnsupported }
+func UpdateLotUsage(string, bool, string) error                            { return errUnsupported }
+func UpdateLotUsageByDir(string, bool, int64, string) error                { return errUnsupported }
 func GetPolicyAttributes(PolicyAttrsRequest) (*RestrictiveMPA, error)      { return nil, errUnsupported }
 func GetLotDirs(string, bool) ([]LotPath, error)                           { return nil, errUnsupported }
 func GetLotUsage(UsageRequest) (*LotUsage, error)                          { return nil, errUnsupported }

--- a/lotman/lotman_bindings_test.go
+++ b/lotman/lotman_bindings_test.go
@@ -181,7 +181,7 @@ func TestLotmanNewBindings(t *testing.T) {
 	t.Run("GetLotsPastExp", func(t *testing.T) {
 		// The configured expiration_time for test-1 and test-2 is 12345ms
 		// since the epoch -- decades in the past.
-		expired, err := GetLotsPastExp(false)
+		expired, err := GetLotsPastExp(false, false)
 		require.NoError(t, err)
 		assert.Contains(t, expired, "test-1")
 		assert.Contains(t, expired, "test-2")
@@ -189,7 +189,7 @@ func TestLotmanNewBindings(t *testing.T) {
 
 	t.Run("GetLotsPastDel", func(t *testing.T) {
 		// deletion_time was 123456ms -- also long past.
-		past, err := GetLotsPastDel(false)
+		past, err := GetLotsPastDel(false, false)
 		require.NoError(t, err)
 		assert.Contains(t, past, "test-1")
 	})
@@ -198,17 +198,17 @@ func TestLotmanNewBindings(t *testing.T) {
 		// No usage reported -> nothing is past dedicated quota. We mainly want
 		// to confirm the binding round-trips without error and respects the
 		// hierarchical flag.
-		_, err := GetLotsPastDed(true, false, true)
+		_, err := GetLotsPastDed(true, false, false, true)
 		require.NoError(t, err)
 	})
 
 	t.Run("GetLotsPastOpp", func(t *testing.T) {
-		_, err := GetLotsPastOpp(true, false, false)
+		_, err := GetLotsPastOpp(true, false, false, false)
 		require.NoError(t, err)
 	})
 
 	t.Run("GetLotsPastObj", func(t *testing.T) {
-		_, err := GetLotsPastObj(true, false, false)
+		_, err := GetLotsPastObj(true, false, false, false)
 		require.NoError(t, err)
 	})
 

--- a/lotman/lotman_bindings_test.go
+++ b/lotman/lotman_bindings_test.go
@@ -181,7 +181,7 @@ func TestLotmanNewBindings(t *testing.T) {
 	t.Run("GetLotsPastExp", func(t *testing.T) {
 		// The configured expiration_time for test-1 and test-2 is 12345ms
 		// since the epoch -- decades in the past.
-		expired, err := GetLotsPastExp(false, false)
+		expired, err := GetLotsPastExp(time.Now().UnixMilli(), false, false)
 		require.NoError(t, err)
 		assert.Contains(t, expired, "test-1")
 		assert.Contains(t, expired, "test-2")
@@ -189,7 +189,7 @@ func TestLotmanNewBindings(t *testing.T) {
 
 	t.Run("GetLotsPastDel", func(t *testing.T) {
 		// deletion_time was 123456ms -- also long past.
-		past, err := GetLotsPastDel(false, false)
+		past, err := GetLotsPastDel(time.Now().UnixMilli(), false, false)
 		require.NoError(t, err)
 		assert.Contains(t, past, "test-1")
 	})

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -81,15 +81,32 @@ var (
 	// runtime will handle the memory management for the *unsafe.Pointer.
 	LotmanGetLotOwners func(lotName string, recursive bool, output *unsafe.Pointer, errMsg *[]byte) int32
 	// Here, getSelf means get the lot proper if it's a self parent
-	LotmanGetLotParents   func(lotName string, recursive bool, getSelf bool, output *unsafe.Pointer, errMsg *[]byte) int32
-	LotmanGetLotChildren  func(lotName string, recursive bool, getSelf bool, output *unsafe.Pointer, errMsg *[]byte) int32
-	LotmanGetLotsFromDir  func(dir string, recursive bool, queryTimeMs int64, output *unsafe.Pointer, errMsg *[]byte) int32
-	LotmanListAllLots     func(output *unsafe.Pointer, errMsg *[]byte) int32
-	LotmanGetLotsPastExp  func(recursive bool, output *unsafe.Pointer, errMsg *[]byte) int32
-	LotmanGetLotsPastDel  func(recursive bool, output *unsafe.Pointer, errMsg *[]byte) int32
-	LotmanGetLotsPastDed  func(recursiveQuota bool, recursiveChildren bool, output *unsafe.Pointer, hierarchical bool, errMsg *[]byte) int32
-	LotmanGetLotsPastOpp  func(recursiveQuota bool, recursiveChildren bool, output *unsafe.Pointer, hierarchical bool, errMsg *[]byte) int32
-	LotmanGetLotsPastObj  func(recursiveQuota bool, recursiveChildren bool, output *unsafe.Pointer, hierarchical bool, errMsg *[]byte) int32
+	LotmanGetLotParents  func(lotName string, recursive bool, getSelf bool, output *unsafe.Pointer, errMsg *[]byte) int32
+	LotmanGetLotChildren func(lotName string, recursive bool, getSelf bool, output *unsafe.Pointer, errMsg *[]byte) int32
+	LotmanGetLotsFromDir func(dir string, recursive bool, queryTimeMs int64, output *unsafe.Pointer, errMsg *[]byte) int32
+	LotmanListAllLots    func(output *unsafe.Pointer, errMsg *[]byte) int32
+	// past_* signatures gained an `include_reclaimed` bool in lotman v0.0.5+
+	// (after the reclamations ledger was added). Cleanup loops should pass
+	// false to avoid repeatedly draining lots that have already been reclaimed.
+	LotmanGetLotsPastExp func(recursive bool, includeReclaimed bool, output *unsafe.Pointer, errMsg *[]byte) int32
+	LotmanGetLotsPastDel func(recursive bool, includeReclaimed bool, output *unsafe.Pointer, errMsg *[]byte) int32
+	LotmanGetLotsPastDed func(recursiveQuota bool, recursiveChildren bool, includeReclaimed bool, output *unsafe.Pointer, hierarchical bool, errMsg *[]byte) int32
+	LotmanGetLotsPastOpp func(recursiveQuota bool, recursiveChildren bool, includeReclaimed bool, output *unsafe.Pointer, hierarchical bool, errMsg *[]byte) int32
+	LotmanGetLotsPastObj func(recursiveQuota bool, recursiveChildren bool, includeReclaimed bool, output *unsafe.Pointer, hierarchical bool, errMsg *[]byte) int32
+
+	// Reclamation ledger (lotman v0.0.5+). LotmanReclaimLot records that the
+	// caller (typically the purge plugin) is no longer attributing bytes to
+	// the named lot subtree; downstream past_* queries with
+	// include_reclaimed=false ignore reclaimed lots.
+	LotmanReclaimLot func(lotName string, reclaimedAtMs int64, reason string, errMsg *[]byte) int32
+
+	// Usage update entry points. Both accept a delta_mode bool: when false,
+	// the supplied JSON describes ABSOLUTE current usage (preferred); when
+	// true, it describes additive deltas. Pelican (and the purge plugin)
+	// always pass delta_mode=false so that on-disk state is the source of
+	// truth and missed updates self-heal on the next reporting tick.
+	LotmanUpdateLotUsage      func(updateJSON string, deltaMode bool, errMsg *[]byte) int32
+	LotmanUpdateLotUsageByDir func(updateJSON string, deltaMode bool, queryTimeMs int64, errMsg *[]byte) int32
 
 	// Functions returning a single JSON document via char **
 	LotmanGetPolicyAttributes  func(requestJSON string, output *[]byte, errMsg *[]byte) int32
@@ -1223,6 +1240,9 @@ func InitLotman(adsFromFed []server_structs.NamespaceAdV2) bool {
 	purego.RegisterLibFunc(&LotmanGetLotsPastDed, lotmanLib, "lotman_get_lots_past_ded")
 	purego.RegisterLibFunc(&LotmanGetLotsPastOpp, lotmanLib, "lotman_get_lots_past_opp")
 	purego.RegisterLibFunc(&LotmanGetLotsPastObj, lotmanLib, "lotman_get_lots_past_obj")
+	purego.RegisterLibFunc(&LotmanReclaimLot, lotmanLib, "lotman_reclaim_lot")
+	purego.RegisterLibFunc(&LotmanUpdateLotUsage, lotmanLib, "lotman_update_lot_usage")
+	purego.RegisterLibFunc(&LotmanUpdateLotUsageByDir, lotmanLib, "lotman_update_lot_usage_by_dir")
 	purego.RegisterLibFunc(&LotmanGetPolicyAttributes, lotmanLib, "lotman_get_policy_attributes")
 	purego.RegisterLibFunc(&LotmanGetLotDirs, lotmanLib, "lotman_get_lot_dirs")
 	purego.RegisterLibFunc(&LotmanGetLotUsage, lotmanLib, "lotman_get_lot_usage")
@@ -1381,6 +1401,9 @@ func InitLotman(adsFromFed []server_structs.NamespaceAdV2) bool {
 //	  } (REQUIRED)
 //	}
 func CreateLot(newLot *Lot, caller string) error {
+	if err := validateLotLifetime(newLot); err != nil {
+		return err
+	}
 	// Marshal the JSON into a string for the C function
 	lotJSON, err := json.Marshal(*newLot)
 	if err != nil {
@@ -1461,6 +1484,9 @@ func GetLot(lotName string, recursive bool) (*Lot, error) {
 //	  } (OPTIONAL)
 //	}
 func UpdateLot(lotUpdate *LotUpdate, caller string) error {
+	if err := validateLotUpdateLifetime(lotUpdate); err != nil {
+		return err
+	}
 	// Marshal the JSON into a string for the C function
 	updateJSON, err := json.Marshal(*lotUpdate)
 	if err != nil {
@@ -1755,41 +1781,127 @@ func pastLotsHelper(name string, fn func(*unsafe.Pointer, *[]byte) int32) ([]str
 
 // GetLotsPastExp returns all lots past their expiration_time. If recursive,
 // the most-restricting ancestor expiration_time is used.
-func GetLotsPastExp(recursive bool) ([]string, error) {
+// If includeReclaimed is false (the typical cleanup-loop value) lots with
+// a reclamations-ledger row are excluded.
+func GetLotsPastExp(recursive, includeReclaimed bool) ([]string, error) {
 	return pastLotsHelper("lots-past-exp", func(out *unsafe.Pointer, errMsg *[]byte) int32 {
-		return LotmanGetLotsPastExp(recursive, out, errMsg)
+		return LotmanGetLotsPastExp(recursive, includeReclaimed, out, errMsg)
 	})
 }
 
 // GetLotsPastDel returns all lots past their deletion_time.
-func GetLotsPastDel(recursive bool) ([]string, error) {
+// See GetLotsPastExp for the meaning of includeReclaimed.
+func GetLotsPastDel(recursive, includeReclaimed bool) ([]string, error) {
 	return pastLotsHelper("lots-past-del", func(out *unsafe.Pointer, errMsg *[]byte) int32 {
-		return LotmanGetLotsPastDel(recursive, out, errMsg)
+		return LotmanGetLotsPastDel(recursive, includeReclaimed, out, errMsg)
 	})
 }
 
 // GetLotsPastDed returns all lots past their dedicated_GB quota.
 // When hierarchical is true, recursiveQuota and recursiveChildren are ignored
 // (the hierarchical query path supersedes them) and results are returned
-// depth-ordered (deepest first).
-func GetLotsPastDed(recursiveQuota, recursiveChildren, hierarchical bool) ([]string, error) {
+// depth-ordered (deepest first). When hierarchical is true, reclaimed parents
+// are unconditionally excluded regardless of includeReclaimed.
+func GetLotsPastDed(recursiveQuota, recursiveChildren, includeReclaimed, hierarchical bool) ([]string, error) {
 	return pastLotsHelper("lots-past-ded", func(out *unsafe.Pointer, errMsg *[]byte) int32 {
-		return LotmanGetLotsPastDed(recursiveQuota, recursiveChildren, out, hierarchical, errMsg)
+		return LotmanGetLotsPastDed(recursiveQuota, recursiveChildren, includeReclaimed, out, hierarchical, errMsg)
 	})
 }
 
 // GetLotsPastOpp returns all lots past their opportunistic_GB quota.
-func GetLotsPastOpp(recursiveQuota, recursiveChildren, hierarchical bool) ([]string, error) {
+func GetLotsPastOpp(recursiveQuota, recursiveChildren, includeReclaimed, hierarchical bool) ([]string, error) {
 	return pastLotsHelper("lots-past-opp", func(out *unsafe.Pointer, errMsg *[]byte) int32 {
-		return LotmanGetLotsPastOpp(recursiveQuota, recursiveChildren, out, hierarchical, errMsg)
+		return LotmanGetLotsPastOpp(recursiveQuota, recursiveChildren, includeReclaimed, out, hierarchical, errMsg)
 	})
 }
 
 // GetLotsPastObj returns all lots past their max_num_objects quota.
-func GetLotsPastObj(recursiveQuota, recursiveChildren, hierarchical bool) ([]string, error) {
+func GetLotsPastObj(recursiveQuota, recursiveChildren, includeReclaimed, hierarchical bool) ([]string, error) {
 	return pastLotsHelper("lots-past-obj", func(out *unsafe.Pointer, errMsg *[]byte) int32 {
-		return LotmanGetLotsPastObj(recursiveQuota, recursiveChildren, out, hierarchical, errMsg)
+		return LotmanGetLotsPastObj(recursiveQuota, recursiveChildren, includeReclaimed, out, hierarchical, errMsg)
 	})
+}
+
+// ReclaimLot records a reclamations-ledger entry for the named lot and every
+// descendant in its subtree. After this call, lots in the subtree are skipped
+// by past_* queries called with includeReclaimed=false; their MPAs and usage
+// rows remain intact in the database. The default lot may NOT be reclaimed.
+//
+// Returns:
+//   - LOTMAN_RECLAIM_OK          (0): at least one new ledger row was added.
+//   - LOTMAN_RECLAIM_ALREADY_RECLAIMED (1): every lot in the subtree was
+//     already reclaimed; no new row was added (still a success).
+//   - LOTMAN_RECLAIM_ERROR       (-1): validation/authorization/storage error.
+//
+// Pelican itself never calls this from production code paths today --
+// reclamation is performed by the xrootd-lotman purge plugin once a lot's
+// bytes have actually been drained off disk. The wrapper exists for tests
+// and for future GC scheduling.
+func ReclaimLot(lotName string, reclaimedAtMs int64, reason, caller string) (int, error) {
+	errMsg := make([]byte, 2048)
+	callerMutex.Lock()
+	defer callerMutex.Unlock()
+	ret := LotmanSetContextStr("caller", caller, &errMsg)
+	if ret != 0 {
+		trimBuf(&errMsg)
+		return LOTMAN_RECLAIM_ERROR, errors.Errorf("error setting caller for lot reclamation: %s", string(errMsg))
+	}
+	ret = LotmanReclaimLot(lotName, reclaimedAtMs, reason, &errMsg)
+	if ret == LOTMAN_RECLAIM_ERROR {
+		trimBuf(&errMsg)
+		return LOTMAN_RECLAIM_ERROR, errors.Errorf("error reclaiming lot %s: %s", lotName, string(errMsg))
+	}
+	return int(ret), nil
+}
+
+// Reclamation status sentinels matching lotman.h.
+const (
+	LOTMAN_RECLAIM_OK                = 0
+	LOTMAN_RECLAIM_ALREADY_RECLAIMED = 1
+	LOTMAN_RECLAIM_ERROR             = -1
+)
+
+// UpdateLotUsage submits an absolute (delta_mode=false) or additive
+// (delta_mode=true) usage update keyed by lot name. updateJSON is the
+// pre-marshalled JSON document accepted by lotman_update_lot_usage.
+func UpdateLotUsage(updateJSON string, deltaMode bool, caller string) error {
+	errMsg := make([]byte, 2048)
+	callerMutex.Lock()
+	defer callerMutex.Unlock()
+	ret := LotmanSetContextStr("caller", caller, &errMsg)
+	if ret != 0 {
+		trimBuf(&errMsg)
+		return errors.Errorf("error setting caller for usage update: %s", string(errMsg))
+	}
+	ret = LotmanUpdateLotUsage(updateJSON, deltaMode, &errMsg)
+	if ret != 0 {
+		trimBuf(&errMsg)
+		return errors.Errorf("error updating lot usage: %s", string(errMsg))
+	}
+	return nil
+}
+
+// UpdateLotUsageByDir submits a path-keyed usage update; lotman resolves each
+// directory to its currently owning lot at the supplied queryTimeMs (0 = now)
+// using longest-prefix matching across every lot's paths.
+func UpdateLotUsageByDir(updateJSON string, deltaMode bool, queryTimeMs int64, caller string) error {
+	if queryTimeMs == 0 {
+		queryTimeMs = time.Now().UnixMilli()
+	}
+	errMsg := make([]byte, 2048)
+	callerMutex.Lock()
+	defer callerMutex.Unlock()
+	ret := LotmanSetContextStr("caller", caller, &errMsg)
+	if ret != 0 {
+		trimBuf(&errMsg)
+		return errors.Errorf("error setting caller for by-dir usage update: %s", string(errMsg))
+	}
+	ret = LotmanUpdateLotUsageByDir(updateJSON, deltaMode, queryTimeMs, &errMsg)
+	if ret != 0 {
+		trimBuf(&errMsg)
+		return errors.Errorf("error updating lot usage by dir: %s", string(errMsg))
+	}
+	return nil
 }
 
 // GetPolicyAttributes returns the most-restrictive MPA values for each axis

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -85,11 +85,22 @@ var (
 	LotmanGetLotChildren func(lotName string, recursive bool, getSelf bool, output *unsafe.Pointer, errMsg *[]byte) int32
 	LotmanGetLotsFromDir func(dir string, recursive bool, queryTimeMs int64, output *unsafe.Pointer, errMsg *[]byte) int32
 	LotmanListAllLots    func(output *unsafe.Pointer, errMsg *[]byte) int32
-	// past_* signatures gained an `include_reclaimed` bool in lotman v0.0.5+
-	// (after the reclamations ledger was added). Cleanup loops should pass
-	// false to avoid repeatedly draining lots that have already been reclaimed.
-	LotmanGetLotsPastExp func(recursive bool, includeReclaimed bool, output *unsafe.Pointer, errMsg *[]byte) int32
-	LotmanGetLotsPastDel func(recursive bool, includeReclaimed bool, output *unsafe.Pointer, errMsg *[]byte) int32
+	// Window-aware variant of lotman_get_lots_from_dir (lotman PR #52). Returns a
+	// JSON array of full lot objects (same shape as lotman_get_lot_as_json with
+	// recursive=false) for every lot that wins the longest-prefix path-resolution
+	// contest at any instant in the half-open window [timeLoMs, timeHiMs). Used
+	// by the renewal scheduler to enumerate just the lots that touch a given
+	// namespace path during the planning window, replacing the O(all lots)
+	// listAllLotsFull walk.
+	LotmanGetLotsForPath func(path string, recursive bool, timeLoMs int64, timeHiMs int64, includeReclaimed bool, output *[]byte, errMsg *[]byte) int32
+	// past_exp/past_del signatures gained a leading `int64 query_time` in lotman
+	// PR #52 to let callers reason about future or past states of the ledger
+	// (preview which lots will be expired/deletable by some timestamp). Pass
+	// wall-clock now() in milliseconds for the historical "as of now" semantics.
+	// `include_reclaimed` was added in v0.0.5+; cleanup loops should pass false
+	// to avoid repeatedly draining lots that have already been reclaimed.
+	LotmanGetLotsPastExp func(queryTimeMs int64, recursive bool, includeReclaimed bool, output *unsafe.Pointer, errMsg *[]byte) int32
+	LotmanGetLotsPastDel func(queryTimeMs int64, recursive bool, includeReclaimed bool, output *unsafe.Pointer, errMsg *[]byte) int32
 	LotmanGetLotsPastDed func(recursiveQuota bool, recursiveChildren bool, includeReclaimed bool, output *unsafe.Pointer, hierarchical bool, errMsg *[]byte) int32
 	LotmanGetLotsPastOpp func(recursiveQuota bool, recursiveChildren bool, includeReclaimed bool, output *unsafe.Pointer, hierarchical bool, errMsg *[]byte) int32
 	LotmanGetLotsPastObj func(recursiveQuota bool, recursiveChildren bool, includeReclaimed bool, output *unsafe.Pointer, hierarchical bool, errMsg *[]byte) int32
@@ -818,20 +829,47 @@ func configLotsFromFedPrefixesNested(nsAds []server_structs.NamespaceAdV2, feder
 }
 
 // computeRootDedicatedGB picks the per-axis dedicated quota for the root
-// lot in GB. When at least one cache disk is detected we use the full
-// disk total (so root's quota naturally contains every child's
-// allocation). When no disks are detected (tests, early startup) we fall
-// back to Cache.HighWaterMark so the root lot is still non-zero and
-// strict-hierarchy axiom 1 remains satisfiable.
+// lot in GB. The cache cannot actually retain more than its HighWaterMark
+// before xrootd's pfc purger starts evicting, so handing the lot system
+// "raw disk total" as the root dedicated quota would let lots provision
+// space the cache can never honour at steady state. The result is
+// therefore the smaller of:
+//   - bytesToGigabytes(totalDiskSpaceB) (the physical capacity of the
+//     cache's data disks), clamped down by the parsed
+//     Cache.HighWaterMark fraction/value where one is configured; and
+//   - any explicit Cache.FilesMaxSize ceiling.
+//
+// When no cache disks are detected (tests, early startup) we fall back
+// to Cache.HighWaterMark interpreted as an absolute byte value so the
+// root lot is still non-zero and lotman's first axiom remains
+// satisfiable.
 func computeRootDedicatedGB(totalDiskSpaceB uint64) float64 {
 	rootDedGB := bytesToGigabytes(totalDiskSpaceB)
+	hwmStr := param.Cache_HighWaterMark.GetString()
 	if totalDiskSpaceB == 0 {
-		hwmStr := param.Cache_HighWaterMark.GetString()
 		if hwmStr != "" {
 			hwmBytes, hwmErr := convertWatermarkToBytes(hwmStr, 0)
 			if hwmErr == nil && hwmBytes > 0 {
 				rootDedGB = bytesToGigabytes(hwmBytes)
 				log.Debugf("No cache disks detected; using HighWaterMark (%s = %.2f GB) as root lot quota", hwmStr, rootDedGB)
+			}
+		}
+		return rootDedGB
+	}
+	// Clamp to HighWaterMark when one is configured: anything above HWM
+	// is unreachable steady-state because xrootd will purge it.
+	if hwmStr != "" {
+		if hwmBytes, hwmErr := convertWatermarkToBytes(hwmStr, totalDiskSpaceB); hwmErr == nil && hwmBytes > 0 {
+			if clamped := bytesToGigabytes(hwmBytes); clamped < rootDedGB {
+				rootDedGB = clamped
+			}
+		}
+	}
+	// Clamp to FilesMaxSize when set (absolute byte value or percent).
+	if maxStr := param.Cache_FilesMaxSize.GetString(); maxStr != "" {
+		if maxBytes, maxErr := convertWatermarkToBytes(maxStr, totalDiskSpaceB); maxErr == nil && maxBytes > 0 {
+			if clamped := bytesToGigabytes(maxBytes); clamped < rootDedGB {
+				rootDedGB = clamped
 			}
 		}
 	}
@@ -1234,6 +1272,7 @@ func InitLotman(adsFromFed []server_structs.NamespaceAdV2) bool {
 	purego.RegisterLibFunc(&LotmanGetLotParents, lotmanLib, "lotman_get_parent_names")
 	purego.RegisterLibFunc(&LotmanGetLotChildren, lotmanLib, "lotman_get_children_names")
 	purego.RegisterLibFunc(&LotmanGetLotsFromDir, lotmanLib, "lotman_get_lots_from_dir")
+	purego.RegisterLibFunc(&LotmanGetLotsForPath, lotmanLib, "lotman_get_lots_for_path")
 	purego.RegisterLibFunc(&LotmanListAllLots, lotmanLib, "lotman_list_all_lots")
 	purego.RegisterLibFunc(&LotmanGetLotsPastExp, lotmanLib, "lotman_get_lots_past_exp")
 	purego.RegisterLibFunc(&LotmanGetLotsPastDel, lotmanLib, "lotman_get_lots_past_del")
@@ -1767,6 +1806,39 @@ func GetLotsFromDir(dir string, recursive bool, queryTimeMs int64) ([]string, er
 	return drainStringList(&out), nil
 }
 
+// GetLotsForPath returns full Lot objects for every lot that "wins" the
+// longest-prefix path-resolution contest at any instant in the half-open
+// window [timeLoMs, timeHiMs). Two lots may both be returned when each owns
+// the path during disjoint sub-intervals of the window. When recursive is
+// true, each winner's ancestors are also included. When includeReclaimed is
+// false, lots reclaimed at or before timeLoMs are dropped entirely; lots
+// reclaimed mid-window have their effective active interval clipped before
+// the sweep. The result always contains at least one element: when no lot
+// wins anywhere in the window, the synthetic "default" lot is appended.
+//
+// This is the window-aware variant of GetLotsFromDir (lotman PR #52). The
+// renewal scheduler uses it to enumerate just the lots that touch a given
+// namespace path during its planning window, which lets it scope work to
+// O(active subtree size) instead of O(total lot rows).
+func GetLotsForPath(path string, recursive bool, timeLoMs, timeHiMs int64, includeReclaimed bool) ([]Lot, error) {
+	// 64 KiB is generous; a typical query returns 2-5 lots × ~1 KiB each.
+	// trimBuf scans for the trailing null terminator so an oversized buffer
+	// is harmless.
+	output := make([]byte, 65536)
+	errMsg := make([]byte, 2048)
+	ret := LotmanGetLotsForPath(path, recursive, timeLoMs, timeHiMs, includeReclaimed, &output, &errMsg)
+	if ret != 0 {
+		trimBuf(&errMsg)
+		return nil, errors.Errorf("error getting lots for path %s in window [%d, %d): %s", path, timeLoMs, timeHiMs, string(errMsg))
+	}
+	trimBuf(&output)
+	var lots []Lot
+	if err := json.Unmarshal(output, &lots); err != nil {
+		return nil, errors.Wrapf(err, "error unmarshalling lots-for-path JSON for %s", path)
+	}
+	return lots, nil
+}
+
 // pastLotsHelper centralises the past-quota query pattern.
 func pastLotsHelper(name string, fn func(*unsafe.Pointer, *[]byte) int32) ([]string, error) {
 	errMsg := make([]byte, 2048)
@@ -1779,21 +1851,25 @@ func pastLotsHelper(name string, fn func(*unsafe.Pointer, *[]byte) int32) ([]str
 	return drainStringList(&out), nil
 }
 
-// GetLotsPastExp returns all lots past their expiration_time. If recursive,
-// the most-restricting ancestor expiration_time is used.
+// GetLotsPastExp returns all lots past their expiration_time relative to
+// the supplied queryTimeMs cutoff (a Unix timestamp in milliseconds). Pass
+// time.Now().UnixMilli() for the historical "as of now" semantics; pass a
+// future timestamp to preview which lots will be expired by then. If
+// recursive, the most-restricting ancestor expiration_time is used.
 // If includeReclaimed is false (the typical cleanup-loop value) lots with
-// a reclamations-ledger row are excluded.
-func GetLotsPastExp(recursive, includeReclaimed bool) ([]string, error) {
+// a reclamations-ledger row whose reclaimed_at <= queryTimeMs are excluded.
+func GetLotsPastExp(queryTimeMs int64, recursive, includeReclaimed bool) ([]string, error) {
 	return pastLotsHelper("lots-past-exp", func(out *unsafe.Pointer, errMsg *[]byte) int32 {
-		return LotmanGetLotsPastExp(recursive, includeReclaimed, out, errMsg)
+		return LotmanGetLotsPastExp(queryTimeMs, recursive, includeReclaimed, out, errMsg)
 	})
 }
 
-// GetLotsPastDel returns all lots past their deletion_time.
-// See GetLotsPastExp for the meaning of includeReclaimed.
-func GetLotsPastDel(recursive, includeReclaimed bool) ([]string, error) {
+// GetLotsPastDel returns all lots past their deletion_time relative to the
+// supplied queryTimeMs cutoff. See GetLotsPastExp for the meaning of
+// queryTimeMs and includeReclaimed.
+func GetLotsPastDel(queryTimeMs int64, recursive, includeReclaimed bool) ([]string, error) {
 	return pastLotsHelper("lots-past-del", func(out *unsafe.Pointer, errMsg *[]byte) int32 {
-		return LotmanGetLotsPastDel(recursive, includeReclaimed, out, errMsg)
+		return LotmanGetLotsPastDel(queryTimeMs, recursive, includeReclaimed, out, errMsg)
 	})
 }
 
@@ -1828,10 +1904,10 @@ func GetLotsPastObj(recursiveQuota, recursiveChildren, includeReclaimed, hierarc
 // rows remain intact in the database. The default lot may NOT be reclaimed.
 //
 // Returns:
-//   - LOTMAN_RECLAIM_OK          (0): at least one new ledger row was added.
-//   - LOTMAN_RECLAIM_ALREADY_RECLAIMED (1): every lot in the subtree was
+//   - lotmanReclaimOK          (0): at least one new ledger row was added.
+//   - lotmanReclaimAlreadyDone  (1): every lot in the subtree was
 //     already reclaimed; no new row was added (still a success).
-//   - LOTMAN_RECLAIM_ERROR       (-1): validation/authorization/storage error.
+//   - lotmanReclaimError       (-1): validation/authorization/storage error.
 //
 // Pelican itself never calls this from production code paths today --
 // reclamation is performed by the xrootd-lotman purge plugin once a lot's
@@ -1844,21 +1920,21 @@ func ReclaimLot(lotName string, reclaimedAtMs int64, reason, caller string) (int
 	ret := LotmanSetContextStr("caller", caller, &errMsg)
 	if ret != 0 {
 		trimBuf(&errMsg)
-		return LOTMAN_RECLAIM_ERROR, errors.Errorf("error setting caller for lot reclamation: %s", string(errMsg))
+		return lotmanReclaimError, errors.Errorf("error setting caller for lot reclamation: %s", string(errMsg))
 	}
 	ret = LotmanReclaimLot(lotName, reclaimedAtMs, reason, &errMsg)
-	if ret == LOTMAN_RECLAIM_ERROR {
+	if ret == lotmanReclaimError {
 		trimBuf(&errMsg)
-		return LOTMAN_RECLAIM_ERROR, errors.Errorf("error reclaiming lot %s: %s", lotName, string(errMsg))
+		return lotmanReclaimError, errors.Errorf("error reclaiming lot %s: %s", lotName, string(errMsg))
 	}
 	return int(ret), nil
 }
 
 // Reclamation status sentinels matching lotman.h.
 const (
-	LOTMAN_RECLAIM_OK                = 0
-	LOTMAN_RECLAIM_ALREADY_RECLAIMED = 1
-	LOTMAN_RECLAIM_ERROR             = -1
+	lotmanReclaimOK          = 0
+	lotmanReclaimAlreadyDone = 1
+	lotmanReclaimError       = -1
 )
 
 // UpdateLotUsage submits an absolute (delta_mode=false) or additive

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -1212,8 +1212,9 @@ func setLotmanContextFlags() error {
 	return nil
 }
 
-// minLotmanVersion is the earliest lotman release that supports
-// strict_hierarchy with parent_attributions (lotman PR #43 / v0.0.5).
+// minLotmanVersion is the earliest lotman release that exposes every
+// FFI symbol Pelican's lotman integration registers below. Bump this
+// whenever a new symbol is added to InitLotman.
 const minLotmanVersion = "v0.0.5"
 
 // checkLotmanVersionCompatibility returns true when the loaded libLotMan.so

--- a/lotman/lotman_test.go
+++ b/lotman/lotman_test.go
@@ -955,6 +955,58 @@ func TestConvertWatermarkToBytes(t *testing.T) {
 	}
 }
 
+// TestComputeRootDedicatedGB_ClampsToHWM verifies that the root lot's
+// dedicated quota is clamped down to Cache.HighWaterMark and
+// Cache.FilesMaxSize when those would be lower than raw disk total,
+// since xrootd will purge once usage exceeds those thresholds.
+func TestComputeRootDedicatedGB_ClampsToHWM(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+
+	totalDisk := gigabytesToBytes(1000.0) // 1 TB
+
+	t.Run("no disk falls back to HWM as absolute bytes", func(t *testing.T) {
+		server_utils.ResetTestState()
+		defer server_utils.ResetTestState()
+		require.NoError(t, param.Cache_HighWaterMark.Set("100g"))
+		got := computeRootDedicatedGB(0)
+		require.InDelta(t, 100.0, got, 0.001)
+	})
+
+	t.Run("HWM percent clamps below disk total", func(t *testing.T) {
+		server_utils.ResetTestState()
+		defer server_utils.ResetTestState()
+		require.NoError(t, param.Cache_HighWaterMark.Set("90"))
+		got := computeRootDedicatedGB(totalDisk)
+		// 90% of 1000 GB = 900 GB
+		require.InDelta(t, 900.0, got, 0.001)
+	})
+
+	t.Run("HWM byte value clamps below disk total", func(t *testing.T) {
+		server_utils.ResetTestState()
+		defer server_utils.ResetTestState()
+		require.NoError(t, param.Cache_HighWaterMark.Set("500g"))
+		got := computeRootDedicatedGB(totalDisk)
+		require.InDelta(t, 500.0, got, 0.001)
+	})
+
+	t.Run("HWM higher than disk uses disk total", func(t *testing.T) {
+		server_utils.ResetTestState()
+		defer server_utils.ResetTestState()
+		require.NoError(t, param.Cache_HighWaterMark.Set("100"))
+		got := computeRootDedicatedGB(totalDisk)
+		require.InDelta(t, 1000.0, got, 0.001)
+	})
+
+	t.Run("FilesMaxSize clamps below HWM-clamped disk total", func(t *testing.T) {
+		server_utils.ResetTestState()
+		defer server_utils.ResetTestState()
+		require.NoError(t, param.Cache_HighWaterMark.Set("90"))
+		require.NoError(t, param.Cache_FilesMaxSize.Set("250g"))
+		got := computeRootDedicatedGB(totalDisk)
+		require.InDelta(t, 250.0, got, 0.001)
+	})
+}
+
 // TestStrictHierarchyContextSet verifies that InitLotman installs the
 // strict-hierarchy execution context (PR-2): the three flags
 // strict_hierarchy, contraction_policy, and admin_override must each be

--- a/lotman/lotman_test.go
+++ b/lotman/lotman_test.go
@@ -74,8 +74,8 @@ func setupLotmanFromConf(t *testing.T, readConfig bool, name string, discUrl str
 	// when storing a lot. The auto-created `default` and `root` lots derive
 	// their timestamps from these params, so we must ensure non-zero defaults
 	// regardless of whether the embedded yaml is loaded.
-	require.NoError(t, param.Lotman_DefaultLotExpirationLifetime.Set(2016*time.Hour))
-	require.NoError(t, param.Lotman_DefaultLotDeletionLifetime.Set(4032*time.Hour))
+	require.NoError(t, param.Lotman_DefaultLotExpirationLifetime.Set(168*time.Hour))
+	require.NoError(t, param.Lotman_DefaultLotDeletionLifetime.Set(168*time.Hour))
 	if readConfig {
 		viper.SetConfigType("yaml")
 		err := viper.ReadConfig(strings.NewReader(yamlMockup))
@@ -1030,6 +1030,17 @@ func TestInitLotmanNestedNamespaces(t *testing.T) {
 	defer cleanup()
 	require.True(t, success)
 
+	// Lots are named with v4 UUIDs internally; resolve UUID names by
+	// asking lotman which lot owns the namespace path right now.
+	nowMs := time.Now().UnixMilli()
+	nameForPath := func(p string) string {
+		owners, err := GetLotsFromDir(p, false, nowMs)
+		require.NoErrorf(t, err, "GetLotsFromDir(%q)", p)
+		require.NotEmptyf(t, owners, "no lot owns %q", p)
+		// owners[0] is the most-specific lot for the path.
+		return owners[0]
+	}
+
 	getLot := func(name string) Lot {
 		buf := make([]byte, 8192)
 		errBuf := make([]byte, 2048)
@@ -1044,13 +1055,16 @@ func TestInitLotmanNestedNamespaces(t *testing.T) {
 		return l
 	}
 
-	a := getLot("/a")
-	b := getLot("/a/b")
-	c := getLot("/c")
+	aName := nameForPath("/a")
+	bName := nameForPath("/a/b")
+	cName := nameForPath("/c")
+	a := getLot(aName)
+	b := getLot(bName)
+	c := getLot(cName)
 
 	// Parent linkage as computed by buildLotTree.
 	assert.Equal(t, []string{"root"}, a.Parents)
-	assert.Equal(t, []string{"/a"}, b.Parents)
+	assert.Equal(t, []string{aName}, b.Parents)
 	assert.Equal(t, []string{"root"}, c.Parents)
 
 	// (N+1) allocator: root has HighWaterMark=100GB (no Cache.DataLocations
@@ -1068,10 +1082,10 @@ func TestInitLotmanNestedNamespaces(t *testing.T) {
 	// ParentAttributions wired through to lotman: each child's attribution
 	// equals its own dedicated quota (axiom 1 trivially satisfied).
 	require.Contains(t, a.ParentAttributions, "root")
-	require.Contains(t, b.ParentAttributions, "/a")
+	require.Contains(t, b.ParentAttributions, aName)
 	require.Contains(t, c.ParentAttributions, "root")
 	assert.InDelta(t, 50.0, *a.ParentAttributions["root"].DedicatedGB, 1e-9)
-	assert.InDelta(t, 25.0, *b.ParentAttributions["/a"].DedicatedGB, 1e-9)
+	assert.InDelta(t, 25.0, *b.ParentAttributions[aName].DedicatedGB, 1e-9)
 	assert.InDelta(t, 50.0, *c.ParentAttributions["root"].DedicatedGB, 1e-9)
 
 	// Sentinel propagation (root.opportunistic = -1, root.max_num_objects = -1):

--- a/lotman/renewal.go
+++ b/lotman/renewal.go
@@ -1,0 +1,995 @@
+//go:build linux && !ppc64le
+
+/***************************************************************
+*
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+// Renewal scheduler and lot garbage collector.
+//
+// # Renewal scheduler (renewExpiringLots)
+//
+// Lots have finite expiration times so a misbehaving (or simply forgotten)
+// namespace cannot tie up cache space indefinitely. The scheduler runs on
+// a fixed tick (Lotman.RenewalCheckInterval, default 1h) and ensures that
+// every namespace currently advertised by the federation has at least one
+// lot covering EVERY uncovered region inside the scheduling horizon
+// [now, now+SchedulingHorizon).
+//
+// The scheduler ONLY mints new lots. It never updates an existing lot —
+// every reservation is immutable after creation. Renewal is exclusively
+// the act of producing one or more successor lots whose paths[].Path
+// matches the predecessor's, but whose UUID, creation_time,
+// expiration_time, and deletion_time are fresh.
+//
+// ## Multi-fill within the horizon
+//
+// For each namespace path P, processed shortest-path-first so parents
+// are planned before their children, the planner walks the post-tick
+// timeline (existing ∪ already-planned successors) cursor-by-cursor and
+// fills EVERY hole inside the horizon — not just the first one. Sample
+// timeline before a tick:
+//
+//	now=T0   horizon=T0+H
+//	   |        |
+//	   v        v
+//	[----)  [--)         [---)
+//	     ^^^^   ^^^^^^^^^      ← gaps the planner must fill
+//
+// Each gap is filled by minting a successor whose window is
+//
+//	creation_time   = max(gapStart, predecessor.expiration_time)
+//	expiration_time = min(creation_time + DefaultLotExpirationLifetime,
+//	                      gapEnd,
+//	                      effectiveParent.expiration_time)
+//	deletion_time   = min(creation_time + DefaultLotDeletionLifetime,
+//	                      effectiveParent.deletion_time)
+//	                  capped overall at MaxLotLifetime
+//
+// Gaps narrower than Lotman.MinFillerWidth are left unfilled and a
+// SkipReason is emitted so operators can audit. The default value of
+// Lotman.MinFillerWidth is 0, which means every gap is filled.
+//
+// ## Horizon refusal
+//
+// Successors whose computed creation_time falls beyond now+SchedulingHorizon
+// are NOT minted on this tick; they will be planned on a future tick once
+// "now" advances enough that they fall back inside the horizon. This keeps
+// scheduling decisions tied to a meaningful look-ahead window and lets the
+// system absorb federation-ad churn before committing to a new reservation.
+//
+// ## Parent clamping (axiom 3)
+//
+// Each successor's window is clipped to the effective parent segment
+// active at the would-be creation_time, so lotman's axiom 3 always
+// holds:
+//
+//	child.creation_time   ≥ parent.creation_time
+//	child.expiration_time ≤ parent.expiration_time
+//	child.deletion_time   ≤ parent.deletion_time
+//
+// The effective parent is whichever lot will be active for the parent
+// path AFTER this tick: a freshly-planned parent successor if the
+// parent is also being renewed (which is why we process parents first),
+// otherwise the parent's currently-latest existing lot.
+//
+// ## Epoch-aware quota stamping (allocateEpochAwareQuotas)
+//
+// After the planner has selected windows for every successor, the
+// allocator stamps each successor's dedicated_GB. Because reservations
+// are immutable, the stamped value must remain feasible for the
+// successor's WHOLE lifetime — even if siblings appear or disappear
+// later in that lifetime. The allocator therefore partitions the
+// successor's window into "epochs" (maximal half-open intervals during
+// which the active sibling set is constant) and stamps
+//
+//	dedicated_GB = min over epochs e of
+//	    (parent_dedicated_in_e − Σ active_sibling.dedicated) / divisor_e
+//
+// where divisor_e is N+1 for top-level paths (sharing root's pool with
+// no reserve) and N+2 for deeper paths (one extra share kept by the
+// parent as reserve, matching lot_tree.go::distribute). Taking the
+// minimum across epochs guarantees axiom 1 (Σ children ≤ parent) holds
+// at every instant the successor will exist. See epoch.go for details.
+//
+// ## Lot names
+//
+// New lot names are fresh UUIDs; paths[].Path carries the human path P.
+//
+// # Lot garbage collector (LaunchLotGcRoutine)
+//
+// Lots whose deletion_time has been in the past for at least
+// Lotman.LotRetention (default 60 days) can be physically removed from
+// the lotman database. This is the only code path in Pelican that ever
+// calls lotman_remove_lot. A lot is assumed to have been reclaimed by
+// the storage layer at or before its deletion_time, so deletion_time
+// alone is the GC trigger:
+//
+//	GC if now − deletion_time ≥ LotRetention
+//
+// The retention window gives operators a forensics window during which
+// historical lot metadata is still inspectable. The GC routine runs at
+// a fixed 24h cadence (not configurable).
+
+package lotman
+
+import (
+	"context"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+// renewalSawAdsOnce flips to true the first time runRenewalTick observes
+// a non-empty ad set, and stays true for the lifetime of the process.
+// runRenewalTick uses it to distinguish a cold-start "no ads yet" tick
+// (DEBUG, expected during boot) from a "we had ads and now we don't"
+// tick (WARN, indicates a director-side regression that will cause
+// coverage to decay).
+var renewalSawAdsOnce atomic.Bool
+
+// SkipReason explains why a particular renewal action was not taken.
+// Returned in RenewalProposal.Skips so callers (and tests) can audit.
+type SkipReason struct {
+	NamespacePath string
+	Reason        string
+}
+
+// RenewalProposal is the fully-precomputed action set the renewal
+// scheduler will apply on a single tick. Splitting "decide" from "apply"
+// keeps the scheduler unit-testable and lets the caller log/audit the
+// plan before committing.
+//
+// The planner only ever proposes new lots. It never proposes mutations
+// of existing lots — every reservation is immutable after creation, and
+// the way to keep coverage going is to mint a fresh successor.
+type RenewalProposal struct {
+	NewLots []Lot
+	Skips   []SkipReason
+}
+
+// renewalConfig captures the tunables threaded into the pure scheduler.
+// Real callers fill this from param.* in LaunchRenewalRoutine; tests
+// supply synthetic values directly.
+//
+// PeriodMs is the scheduler tick interval and is informational here:
+// the planner uses it only to keep tests easy to write. The fill loop
+// is bounded by HorizonMs (Lotman.SchedulingHorizon), not PeriodMs.
+type renewalConfig struct {
+	NowMs             int64
+	PeriodMs          int64
+	HorizonMs         int64
+	MinFillerWidthMs  int64
+	DefaultLifetimeMs int64
+	DefaultDeletionMs int64
+	MaxLifetimeMs     int64
+	RootDedicatedGB   float64
+	FederationIssuer  string
+}
+
+// renewExpiringLots is the pure planner used by LaunchRenewalRoutine.
+// It receives the federation's current namespace ads and the full set of
+// existing lots (typically obtained via listAllLotsFull) and produces a
+// RenewalProposal describing what should change. No FFI calls happen
+// here, so the planner is unit-testable with synthetic Lot slices.
+//
+// # Multi-fill semantics
+//
+// Each tick fills *every* uncovered region of every advertised namespace
+// inside [now, now+SchedulingHorizon) with back-to-back successor lots,
+// trimmed to fit between adjacent existing lots so successor windows
+// never overlap with each other or with pre-existing lots. A lot whose
+// creation_time would fall beyond the horizon is deferred to a later
+// tick (this is the user-facing meaning of Lotman.SchedulingHorizon).
+//
+// Holes shorter than Lotman.MinFillerWidth are recorded as Skips
+// instead of being filled, to avoid producing a swarm of degenerate
+// reservations from naturally-occurring sub-tick gaps. Bytes that
+// arrive during a sub-threshold gap are accounted to the default lot.
+//
+// The planner is intentionally idempotent: re-running it against the
+// outputs of a previous tick produces an empty proposal.
+//
+// # Axiom-3 invariant
+//
+// Lotman's strict_hierarchy mode requires
+//
+//	child.creation_time   ≥ parent.creation_time
+//	child.expiration_time ≤ parent.expiration_time
+//	child.deletion_time   ≤ parent.deletion_time
+//
+// (validated in lotman_internal.cpp::validate_axiom3). The planner
+// satisfies this without ever mutating an existing lot:
+//
+//   - Namespaces are processed parent-before-child (shortest path first,
+//     ties broken alphabetically). Each child's planned successor is
+//     clamped to the parent segment that covers the successor's
+//     creation_time, where "parent segment" means a single lot in the
+//     parent's effective post-tick timeline (existing lots ∪ this
+//     tick's planned parent successors).
+//   - When no parent segment covers a candidate creation_time, the
+//     planner records a Skip and advances past the offending hole.
+//     The next tick will pick up the work once the parent has renewed.
+//
+// The planner does NOT extend existing lots. Every lot is immutable
+// after creation; renewal is exclusively the job of minting fresh
+// successors.
+func renewExpiringLots(cfg renewalConfig, fedAds []server_structs.NamespaceAdV2, existing []Lot) RenewalProposal {
+	prop := RenewalProposal{}
+
+	if cfg.PeriodMs <= 0 || cfg.DefaultLifetimeMs <= 0 {
+		prop.Skips = append(prop.Skips, SkipReason{Reason: "period or default lifetime <= 0"})
+		return prop
+	}
+	if cfg.MaxLifetimeMs > 0 && cfg.DefaultLifetimeMs > cfg.MaxLifetimeMs {
+		// Defensive clamp: never propose a lifetime longer than the cap.
+		// Done BEFORE the horizon check below so a misconfigured-up
+		// DefaultLifetime cannot inflate the horizon past MaxLifetime.
+		cfg.DefaultLifetimeMs = cfg.MaxLifetimeMs
+	}
+	if cfg.HorizonMs <= 0 {
+		// Backwards-compatible fallback for callers that haven't
+		// supplied a horizon: behave like the legacy single-fill
+		// planner whose horizon was just one tick.
+		cfg.HorizonMs = cfg.PeriodMs
+	}
+	if cfg.HorizonMs < cfg.DefaultLifetimeMs {
+		// Defensive: a horizon shorter than the default lifetime is
+		// pathological (every tick mints one lot whose end exceeds the
+		// horizon). Round up so users who misconfigure still get sane
+		// behaviour rather than thrashing.
+		cfg.HorizonMs = cfg.DefaultLifetimeMs
+	}
+	if cfg.MinFillerWidthMs < 0 {
+		cfg.MinFillerWidthMs = 0
+	}
+
+	horizonCreate := cfg.NowMs + cfg.HorizonMs
+
+	// Distinct, non-monitoring namespace paths from the ads, sorted
+	// parent-before-child (by length, ties alphabetical) so a parent's
+	// planned successors are visible when its child is processed.
+	nsPaths := dedupeNamespacePaths(fedAds)
+	sort.Slice(nsPaths, func(i, j int) bool {
+		if len(nsPaths[i]) != len(nsPaths[j]) {
+			return len(nsPaths[i]) < len(nsPaths[j])
+		}
+		return nsPaths[i] < nsPaths[j]
+	})
+
+	// Per-path slice of newly-planned lots, in CreationTime order.
+	// Used both to bound a path's own multi-fill loop (cursor advancement
+	// past a just-planned successor) and to expose freshly-planned parent
+	// successors when a child is processed.
+	plannedByPath := map[string][]*Lot{}
+
+	for _, p := range nsPaths {
+		issuer := cfg.FederationIssuer
+		if iss := issuerForPath(p, fedAds); iss != "" {
+			issuer = iss
+		}
+		// The parent timeline a child must fit inside is the union of
+		// the parent path's existing lots and any already-planned-this-
+		// tick parent successors. Computed once per child for stability
+		// across the multi-fill loop.
+		parentPath := parentNamespacePath(p, existing, plannedByPath)
+		parentTimeline := buildEffectiveTimeline(parentPath, existing, plannedByPath)
+		// Existing-lots-only timeline for this path; planned successors
+		// are tracked via cursor advancement, not by re-injection.
+		ownTimeline := lotsForNamespace(p, existing)
+
+		cursor := cfg.NowMs
+		for cursor < horizonCreate {
+			holeStart, holeEnd, ok := nextHole(ownTimeline, cursor)
+			if !ok || holeStart >= horizonCreate {
+				break
+			}
+			// Successors live strictly in [holeStart, holeEnd). Trim
+			// holeEnd so we never bleed into the next existing lot's
+			// window and produce same-path overlap.
+			gapEnd := holeEnd
+
+			create := holeStart
+			if create < cfg.NowMs {
+				create = cfg.NowMs
+			}
+			if create >= horizonCreate {
+				// Far end of the path's coverage already extends past
+				// horizon; nothing to do this tick.
+				break
+			}
+
+			// Resolve which parent segment (if any) covers `create`.
+			// `parentSeg.ok=false` means the parent has no coverage at
+			// `create`, which forbids axiom-3 compliance: skip this
+			// hole entirely and advance past it.
+			parentSeg := parentSegmentAt(parentTimeline, create)
+			if parentPath != "" && !parentSeg.ok {
+				// The parent will have no live lot at `create`.
+				// Advance past this hole; perhaps the next hole
+				// (after the next existing same-path lot) is covered.
+				prop.Skips = append(prop.Skips, SkipReason{
+					NamespacePath: p,
+					Reason:        "no parent segment covers candidate creation_time; deferring",
+				})
+				cursor = gapEnd
+				if cursor <= holeStart {
+					cursor = holeStart + 1 // defensive against integer wrap
+				}
+				continue
+			}
+			if parentSeg.ok {
+				if create < parentSeg.start {
+					create = parentSeg.start
+				}
+				if create >= horizonCreate {
+					break
+				}
+			}
+
+			lifetime := cfg.DefaultLifetimeMs
+			if cfg.MaxLifetimeMs > 0 && lifetime > cfg.MaxLifetimeMs {
+				lifetime = cfg.MaxLifetimeMs
+			}
+			expire := create + lifetime
+			if expire > gapEnd {
+				expire = gapEnd
+			}
+			if parentSeg.ok && expire > parentSeg.end {
+				expire = parentSeg.end
+			}
+
+			width := expire - create
+			if width <= 0 {
+				cursor = gapEnd
+				if cursor <= holeStart {
+					cursor = holeStart + 1
+				}
+				continue
+			}
+			if cfg.MinFillerWidthMs > 0 && width < cfg.MinFillerWidthMs {
+				prop.Skips = append(prop.Skips, SkipReason{
+					NamespacePath: p,
+					Reason:        "filler width below Lotman.MinFillerWidth; default lot will absorb the gap",
+				})
+				cursor = gapEnd
+				if cursor <= holeStart {
+					cursor = holeStart + 1
+				}
+				continue
+			}
+
+			// Deletion time defaults to create + DefaultDeletionMs but
+			// must be ≥ expire and ≤ parent's deletion bound.
+			del := create + cfg.DefaultDeletionMs
+			if del < expire {
+				del = expire
+			}
+			if parentSeg.ok && del > parentSeg.delEnd {
+				del = parentSeg.delEnd
+			}
+			if del < expire {
+				// Parent's deletion window is tighter than its own
+				// expiration; fall back to expire (still satisfies
+				// axiom 3 because parent.del ≥ parent.exp ≥ expire).
+				del = expire
+			}
+
+			newLot := Lot{
+				LotName: uuid.NewString(),
+				Owner:   issuer,
+				// Parent UUID is filled in by the apply step.
+				Paths: []LotPath{{Path: p, Recursive: true}},
+				MPA: &MPA{
+					CreationTime:   &Int64FromFloat{Value: create},
+					ExpirationTime: &Int64FromFloat{Value: expire},
+					DeletionTime:   &Int64FromFloat{Value: del},
+					// Storage quotas are stamped by allocateEpochAwareQuotas
+					// after every path's timing has been planned.
+				},
+			}
+			prop.NewLots = append(prop.NewLots, newLot)
+			ref := &prop.NewLots[len(prop.NewLots)-1]
+			plannedByPath[p] = append(plannedByPath[p], ref)
+
+			// Advance cursor past the just-planned successor. Continue
+			// the loop so additional gaps inside [now, horizon) are
+			// also filled (e.g. a future existing lot leaves another
+			// hole before its own start).
+			cursor = expire
+			if cursor <= holeStart {
+				cursor = holeStart + 1
+			}
+		}
+	}
+
+	return prop
+}
+
+// parentSegment is one entry in a path's effective post-tick timeline:
+// a single lot that is or will be live for some closed-open window.
+type parentSegment struct {
+	ok     bool  // false → the parent has no coverage at the queried instant
+	start  int64 // creation_time of the covering lot (Unix ms)
+	end    int64 // expiration_time of the covering lot (Unix ms)
+	delEnd int64 // deletion_time of the covering lot (Unix ms)
+}
+
+// buildEffectiveTimeline returns the parent path's full post-tick
+// timeline (existing lots ∪ planned-this-tick successors), sorted by
+// CreationTime ascending. Returns an empty slice when `path == ""`,
+// which conventionally means "synthetic root, no parent clamp".
+//
+// Lots from `planned` are inserted as fresh shallow copies so the
+// returned slice can be iterated without cross-contamination if a
+// caller mutates entries (the planner does not, but the property is
+// useful to preserve).
+func buildEffectiveTimeline(path string, existing []Lot, planned map[string][]*Lot) []Lot {
+	if path == "" {
+		return nil
+	}
+	var out []Lot
+	for _, l := range lotsForNamespace(path, existing) {
+		out = append(out, l)
+	}
+	if planned != nil {
+		for _, l := range planned[path] {
+			if l == nil {
+				continue
+			}
+			out = append(out, *l)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].MPA.CreationTime.Value < out[j].MPA.CreationTime.Value
+	})
+	return out
+}
+
+// parentSegmentAt returns the parent timeline segment that covers
+// `instantMs` under the same half-open semantics as nextHole/nextGap:
+// a lot covers t iff creation_time ≤ t < expiration_time.
+//
+// When `timeline` is empty the result has ok=false. Top-level paths use
+// an empty timeline (their effective parent is the synthetic root lot,
+// which is non-expiring and therefore imposes no clamp); the planner
+// detects this case via parentNamespacePath returning "".
+func parentSegmentAt(timeline []Lot, instantMs int64) parentSegment {
+	for _, l := range timeline {
+		if l.MPA == nil || l.MPA.CreationTime == nil || l.MPA.ExpirationTime == nil {
+			continue
+		}
+		c := l.MPA.CreationTime.Value
+		e := l.MPA.ExpirationTime.Value
+		if c <= instantMs && instantMs < e {
+			seg := parentSegment{ok: true, start: c, end: e, delEnd: e}
+			if l.MPA.DeletionTime != nil {
+				seg.delEnd = l.MPA.DeletionTime.Value
+			}
+			return seg
+		}
+	}
+	return parentSegment{}
+}
+
+// parentNamespacePath returns the longest path that is a strict ancestor
+// of `path` and is either being renewed this tick or has at least one
+// existing lot. Returns "" when no such ancestor exists, in which case
+// the synthetic root lot (non-expiring) is the effective parent and no
+// clamp is applied.
+func parentNamespacePath(path string, existing []Lot, planned map[string][]*Lot) string {
+	target := normaliseLotPath(path)
+	bestPath := ""
+	bestLen := 0
+	consider := func(candidate string) {
+		c := normaliseLotPath(candidate)
+		if c == target {
+			return
+		}
+		if pathContains(c, target) && len(c) > bestLen {
+			bestPath = c
+			bestLen = len(c)
+		}
+	}
+	for p := range planned {
+		consider(p)
+	}
+	for _, l := range existing {
+		for _, p := range l.Paths {
+			consider(p.Path)
+		}
+	}
+	return bestPath
+}
+
+// dedupeNamespacePaths returns the set of distinct, non-monitoring
+// namespace paths advertised by the federation. Order is alphabetical
+// for deterministic output.
+func dedupeNamespacePaths(ads []server_structs.NamespaceAdV2) []string {
+	seen := map[string]struct{}{}
+	for _, a := range ads {
+		p := normaliseLotPath(a.Path)
+		if p == "" || p == "/" {
+			continue
+		}
+		// Skip the monitoring sub-namespace; it's handled separately and
+		// doesn't need lot coverage.
+		if isMonitoringPath(p) {
+			continue
+		}
+		seen[p] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// isMonitoringPath returns true for the cache's monitoring sub-namespace,
+// which Pelican intentionally excludes from lot tracking.
+func isMonitoringPath(p string) bool {
+	mon := normaliseLotPath(server_utils.MonitoringBaseNs)
+	np := normaliseLotPath(p)
+	return np == mon || pathContains(mon, np)
+}
+
+// issuerForPath returns the first ad's issuer URL for the supplied
+// namespace path, or "" when the path is not in `ads` (use the federation
+// fallback) or the matching ad declares no issuer.
+func issuerForPath(p string, ads []server_structs.NamespaceAdV2) string {
+	target := normaliseLotPath(p)
+	for _, a := range ads {
+		if normaliseLotPath(a.Path) != target {
+			continue
+		}
+		if len(a.Issuer) == 0 {
+			return ""
+		}
+		return a.Issuer[0].IssuerUrl.String()
+	}
+	return ""
+}
+
+// ExpirationTimeIsSentinel reports whether the lot uses the "non-expiring"
+// all-zero timestamp sentinel (lotman PR #44). Sentinel lots (root,
+// default) must never be extended by the renewal scheduler.
+func (l Lot) ExpirationTimeIsSentinel() bool {
+	if l.MPA == nil {
+		return true
+	}
+	if l.MPA.CreationTime == nil || l.MPA.ExpirationTime == nil || l.MPA.DeletionTime == nil {
+		return false
+	}
+	return l.MPA.CreationTime.Value == 0 &&
+		l.MPA.ExpirationTime.Value == 0 &&
+		l.MPA.DeletionTime.Value == 0
+}
+
+// LaunchRenewalRoutine starts a background ticker that periodically calls
+// renewExpiringLots and applies the resulting proposal to the lotman DB.
+// It returns immediately; the goroutine exits when ctx is done.
+//
+// getNamespaceAds is supplied by the cache server so the routine reads
+// the live ad set on every tick (rather than capturing a stale snapshot).
+func LaunchRenewalRoutine(ctx context.Context, getNamespaceAds func() []server_structs.NamespaceAdV2) {
+	interval := param.Lotman_RenewalCheckInterval.GetDuration()
+	if interval <= 0 {
+		interval = time.Hour
+	}
+	// Startup-time validation of Lotman.SchedulingHorizon. The runtime
+	// planner will defensively clamp again, but doing it here lets the
+	// operator see one warning at boot rather than one warning per tick
+	// for the lifetime of the process. Clamping is "up": shrinking
+	// horizon below DefaultLotExpirationLifetime makes every tick mint
+	// a lot whose end exceeds the horizon, and shrinking it below the
+	// tick interval causes the planner to keep re-minting the same
+	// lots back-to-back.
+	horizon := param.Lotman_SchedulingHorizon.GetDuration()
+	defLife := param.Lotman_DefaultLotExpirationLifetime.GetDuration()
+	if horizon > 0 && defLife > 0 && horizon < defLife {
+		log.Warnf("Lotman.SchedulingHorizon (%s) is shorter than Lotman.DefaultLotExpirationLifetime (%s); the planner will treat the horizon as %s. Consider raising Lotman.SchedulingHorizon to at least Lotman.DefaultLotExpirationLifetime.",
+			horizon, defLife, defLife)
+	}
+	if horizon > 0 && horizon < interval {
+		log.Warnf("Lotman.SchedulingHorizon (%s) is shorter than Lotman.RenewalCheckInterval (%s); the planner will treat the horizon as %s. Consider raising Lotman.SchedulingHorizon to at least Lotman.RenewalCheckInterval.",
+			horizon, interval, interval)
+	}
+	go func() {
+		log.Infof("Starting Lotman renewal routine; interval=%s", interval)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		// Run an immediate tick so freshly-launched caches converge faster.
+		runRenewalTick(getNamespaceAds, interval)
+		for {
+			select {
+			case <-ctx.Done():
+				log.Info("Lotman renewal routine exiting (context cancelled)")
+				return
+			case <-ticker.C:
+				runRenewalTick(getNamespaceAds, interval)
+			}
+		}
+	}()
+}
+
+// resolveSuccessorParent picks the lot UUID under which a freshly-planned
+// successor should be attached. The chosen parent must cover the
+// successor's creation_time so axiom 3 holds at admission
+// (parent.creation_time ≤ child.creation_time and
+// child.expiration_time ≤ parent.expiration_time).
+//
+// Resolution order:
+//  1. Walk ancestor paths (from any path that has a lot in either
+//     `existing` or `planned`) longest-first.
+//  2. For each candidate ancestor, prefer a planned-this-tick lot whose
+//     window covers `successorCreate`. A planned parent always wins over
+//     an existing one because `renewExpiringLots` clamps successor
+//     windows to the planned-parent window when the existing parent is
+//     itself expiring this tick.
+//  3. Fall back to an existing lot whose window covers
+//     `successorCreate`.
+//  4. If no ancestor covers `successorCreate`, attach to "root". This is
+//     the same branch first-ever lots take.
+//
+// Pure / data-only: no FFI calls, safe to unit-test.
+func resolveSuccessorParent(path string, successorCreate int64, existing []Lot, planned map[string][]*Lot) string {
+	target := normaliseLotPath(path)
+
+	type ancestor struct {
+		path string
+		plen int
+	}
+	seen := map[string]bool{}
+	var ancestors []ancestor
+	consider := func(raw string) {
+		n := normaliseLotPath(raw)
+		if n == "" || n == target || seen[n] {
+			return
+		}
+		if !pathContains(n, target) {
+			return
+		}
+		seen[n] = true
+		ancestors = append(ancestors, ancestor{n, len(n)})
+	}
+	for p := range planned {
+		consider(p)
+	}
+	for _, l := range existing {
+		for _, p := range l.Paths {
+			consider(p.Path)
+		}
+	}
+	sort.Slice(ancestors, func(i, j int) bool { return ancestors[i].plen > ancestors[j].plen })
+
+	covers := func(l *Lot, t int64) bool {
+		if l == nil || l.MPA == nil || l.MPA.CreationTime == nil || l.MPA.ExpirationTime == nil {
+			return false
+		}
+		return l.MPA.CreationTime.Value <= t && t < l.MPA.ExpirationTime.Value
+	}
+
+	for _, a := range ancestors {
+		// (2) Planned parent wins over an existing one.
+		for _, l := range planned[a.path] {
+			if covers(l, successorCreate) {
+				return l.LotName
+			}
+		}
+		// (3) Fall back to an existing covering lot.
+		for _, l := range lotsForNamespace(a.path, existing) {
+			lc := l
+			if covers(&lc, successorCreate) {
+				return l.LotName
+			}
+		}
+	}
+	return "root"
+}
+
+// runRenewalTick executes one cycle of the renewal scheduler. Errors are
+// logged and swallowed so a transient failure does not crash the cache.
+func runRenewalTick(getNamespaceAds func() []server_structs.NamespaceAdV2, period time.Duration) {
+	ads := getNamespaceAds()
+	if len(ads) == 0 {
+		// Distinguish cold-start (cache just booted, director may not
+		// have advertised yet) from a transient outage (we previously
+		// saw ads and now don't). The latter is worth a WARN because
+		// continued ad-loss while existing lots are valid means the
+		// scheduler stops minting successors and coverage decays.
+		if renewalSawAdsOnce.Load() {
+			log.Warn("Lotman renewal: namespace ads disappeared after a previous tick had ads; skipping tick. Coverage will decay if this persists.")
+		} else {
+			log.Debug("Lotman renewal: no namespace ads yet (cold start); skipping tick")
+		}
+		return
+	}
+	renewalSawAdsOnce.Store(true)
+
+	federationIssuer, err := getFederationIssuer()
+	if err != nil || federationIssuer == "" {
+		log.Warnf("Lotman renewal: cannot determine federation issuer; skipping tick: %v", err)
+		return
+	}
+
+	existing, err := listAllLotsFull()
+	if err != nil {
+		log.Warnf("Lotman renewal: failed to enumerate lots: %v", err)
+		return
+	}
+
+	cfg := renewalConfig{
+		NowMs:             time.Now().UnixMilli(),
+		PeriodMs:          period.Milliseconds(),
+		HorizonMs:         param.Lotman_SchedulingHorizon.GetDuration().Milliseconds(),
+		MinFillerWidthMs:  param.Lotman_MinFillerWidth.GetDuration().Milliseconds(),
+		DefaultLifetimeMs: param.Lotman_DefaultLotExpirationLifetime.GetDuration().Milliseconds(),
+		DefaultDeletionMs: param.Lotman_DefaultLotDeletionLifetime.GetDuration().Milliseconds(),
+		MaxLifetimeMs:     param.Lotman_MaxLotLifetime.GetDuration().Milliseconds(),
+		RootDedicatedGB:   rootDedicatedGB(existing),
+		FederationIssuer:  federationIssuer,
+	}
+
+	prop := renewExpiringLots(cfg, ads, existing)
+	if len(prop.NewLots) == 0 {
+		log.Debug("Lotman renewal: nothing to do")
+		return
+	}
+
+	// Stamp epoch-aware storage quotas on every newly-planned lot so
+	// the immutable record reflects a non-contracting share that
+	// remains feasible for the whole life of the lot, even as the
+	// composition of active siblings changes across the lot's lifetime.
+	allocateEpochAwareQuotas(&prop, existing, ads, cfg)
+
+	// Apply proposal. Each step logs its own failures and the loop
+	// continues so a single bad lot does not block the rest. Parent
+	// resolution is delegated to assignSuccessorParents, which is pure
+	// and independently unit-tested so the wiring (creation_time → the
+	// resolver's `successorCreate` argument; planned-this-tick siblings
+	// → its `planned` map) is exercised by tests rather than relying on
+	// the call site being correct by inspection.
+	assignSuccessorParents(prop.NewLots, existing)
+
+	for _, l := range prop.NewLots {
+		if err := CreateLot(&l, federationIssuer); err != nil {
+			log.Warnf("Lotman renewal: failed to create lot for %q: %v", l.Paths[0].Path, err)
+		} else {
+			log.Infof("Lotman renewal: created successor lot %s for %q (parent=%s, expires %s)",
+				l.LotName, l.Paths[0].Path, l.Parents[0],
+				time.UnixMilli(l.MPA.ExpirationTime.Value).Format(time.RFC3339))
+		}
+	}
+}
+
+// assignSuccessorParents fills `Parents[0]` on every lot in `newLots`
+// using resolveSuccessorParent. Pure / data-only so the wiring between
+// runRenewalTick and the resolver can be exercised in unit tests
+// (verifies createTime is sourced from MPA.CreationTime and that the
+// planned-this-tick sibling map is built from `newLots` itself). Mutates
+// `newLots` in place.
+func assignSuccessorParents(newLots []Lot, existing []Lot) {
+	planned := map[string][]*Lot{}
+	for i := range newLots {
+		l := &newLots[i]
+		if len(l.Paths) == 0 {
+			continue
+		}
+		p := normaliseLotPath(l.Paths[0].Path)
+		planned[p] = append(planned[p], l)
+	}
+	for i := range newLots {
+		l := &newLots[i]
+		if len(l.Paths) == 0 {
+			continue
+		}
+		createTime := int64(0)
+		if l.MPA != nil && l.MPA.CreationTime != nil {
+			createTime = l.MPA.CreationTime.Value
+		}
+		l.Parents = []string{resolveSuccessorParent(l.Paths[0].Path, createTime, existing, planned)}
+	}
+}
+
+// LaunchLotGcRoutine starts a background ticker that periodically removes
+// lots whose deletion_time + LotRetention has passed. It returns
+// immediately; the goroutine exits when ctx is done. The cadence is
+// fixed at 24 hours.
+func LaunchLotGcRoutine(ctx context.Context) {
+	const interval = 24 * time.Hour
+	go func() {
+		log.Infof("Starting Lotman GC routine; interval=%s", interval)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				log.Info("Lotman GC routine exiting (context cancelled)")
+				return
+			case <-ticker.C:
+				runGcTick()
+			}
+		}
+	}()
+}
+
+// gcEligibleLots returns the names of lots that runGcTick would remove
+// if invoked at wall-clock `nowMs` with the supplied retention. Pure /
+// data-only so it can be unit-tested without an FFI surface.
+//
+// Eligibility rules:
+//   - Skip the synthetic root and default lots (immutable bookkeeping
+//     entries that lotman creates at startup).
+//   - Skip sentinel-time lots (creation/expiration/deletion all 0):
+//     these are non-expiring by design.
+//   - Skip lots whose deletion_time is unset or 0.
+//   - Otherwise eligible iff `deletion_time + retention <= nowMs`,
+//     equivalently `deletion_time <= nowMs - retention`.
+func gcEligibleLots(existing []Lot, nowMs int64, retention time.Duration) []string {
+	if retention <= 0 {
+		retention = 60 * 24 * time.Hour
+	}
+	cutoffMs := nowMs - retention.Milliseconds()
+	out := make([]string, 0)
+	for _, l := range existing {
+		if l.LotName == "root" || l.LotName == "default" {
+			continue
+		}
+		if l.ExpirationTimeIsSentinel() {
+			continue
+		}
+		if l.MPA == nil || l.MPA.DeletionTime == nil {
+			continue
+		}
+		trigger := l.MPA.DeletionTime.Value
+		if trigger == 0 {
+			continue
+		}
+		if trigger > cutoffMs {
+			continue
+		}
+		out = append(out, l.LotName)
+	}
+	return out
+}
+
+// RemoveLot bool-arg cheat sheet (matches the underlying lotman C API):
+//
+//	assignLTBRParentsToOrphans   reattach orphaned children to the
+//	                              removed lot's parents (else: orphan).
+//	assignLTBRParentsToNonOrphans same, for non-orphan children.
+//	assignPolicyToChildren        copy the removed lot's policy down to
+//	                              its children before removal.
+//	overridePolicy                allow removal even when policy says no.
+//
+// The renewal scheduler's GC always wants the first two true (so a GC
+// cascade does not orphan downstream lots) and the latter two false
+// (we are not propagating policy and never want to override safety
+// checks on a routine GC).
+const (
+	gcReassignOrphans    = true
+	gcReassignNonOrphans = true
+	gcAssignPolicy       = false
+	gcOverridePolicy     = false
+)
+
+// runGcTick removes any lot whose deletion_time was at least LotRetention
+// ago. Failures are logged and swallowed.
+func runGcTick() {
+	federationIssuer, err := getFederationIssuer()
+	if err != nil || federationIssuer == "" {
+		log.Warnf("Lotman GC: cannot determine federation issuer; skipping tick: %v", err)
+		return
+	}
+	retention := param.Lotman_LotRetention.GetDuration()
+
+	existing, err := listAllLotsFull()
+	if err != nil {
+		log.Warnf("Lotman GC: failed to enumerate lots: %v", err)
+		return
+	}
+
+	names := gcEligibleLots(existing, time.Now().UnixMilli(), retention)
+	for _, name := range names {
+		if err := RemoveLot(name, gcReassignOrphans, gcReassignNonOrphans, gcAssignPolicy, gcOverridePolicy, federationIssuer); err != nil {
+			log.Warnf("Lotman GC: failed to remove lot %s: %v", name, err)
+			continue
+		}
+		log.Infof("Lotman GC: removed lot %s", name)
+	}
+}
+
+// validateLotLifetime returns an error if the supplied lot's
+// expiration_time exceeds creation_time + Lotman.MaxLotLifetime. Used by
+// CreateLot/UpdateLot at admission time so lots cannot be minted with
+// arbitrary lifetimes.
+func validateLotLifetime(l *Lot) error {
+	if l == nil || l.MPA == nil || l.MPA.CreationTime == nil || l.MPA.ExpirationTime == nil {
+		return nil
+	}
+	if l.ExpirationTimeIsSentinel() {
+		return nil
+	}
+	maxLifetime := param.Lotman_MaxLotLifetime.GetDuration().Milliseconds()
+	if maxLifetime <= 0 {
+		return nil
+	}
+	span := l.MPA.ExpirationTime.Value - l.MPA.CreationTime.Value
+	if span > maxLifetime {
+		return errors.Errorf(
+			"lot %s expiration_time exceeds Lotman.MaxLotLifetime (%dms requested, max %dms)",
+			l.LotName, span, maxLifetime)
+	}
+	return nil
+}
+
+// validateLotUpdateLifetime enforces Lotman.MaxLotLifetime on the
+// post-update span of any update that touches creation_time or
+// expiration_time. When only one of the two is supplied, the absent
+// field is read from the live lot so the resulting span can be checked
+// without allowing a sneak-extension. Updates that touch neither
+// timestamp are allowed through unchanged.
+func validateLotUpdateLifetime(upd *LotUpdate) error {
+	if upd == nil || upd.MPA == nil {
+		return nil
+	}
+	touchesCreate := upd.MPA.CreationTime != nil
+	touchesExpire := upd.MPA.ExpirationTime != nil
+	if !touchesCreate && !touchesExpire {
+		return nil
+	}
+	create := int64(0)
+	expire := int64(0)
+	if touchesCreate {
+		create = upd.MPA.CreationTime.Value
+	}
+	if touchesExpire {
+		expire = upd.MPA.ExpirationTime.Value
+	}
+	if !touchesCreate || !touchesExpire {
+		live, err := GetLot(upd.LotName, false)
+		if err != nil {
+			return errors.Wrapf(err, "cannot validate update lifetime for lot %s", upd.LotName)
+		}
+		if live == nil || live.MPA == nil {
+			return nil
+		}
+		if !touchesCreate && live.MPA.CreationTime != nil {
+			create = live.MPA.CreationTime.Value
+		}
+		if !touchesExpire && live.MPA.ExpirationTime != nil {
+			expire = live.MPA.ExpirationTime.Value
+		}
+	}
+	probe := &Lot{
+		LotName: upd.LotName,
+		MPA: &MPA{
+			CreationTime:   &Int64FromFloat{Value: create},
+			ExpirationTime: &Int64FromFloat{Value: expire},
+		},
+	}
+	return validateLotLifetime(probe)
+}

--- a/lotman/renewal.go
+++ b/lotman/renewal.go
@@ -29,11 +29,16 @@
 // lot covering EVERY uncovered region inside the scheduling horizon
 // [now, now+SchedulingHorizon).
 //
-// The scheduler ONLY mints new lots. It never updates an existing lot —
-// every reservation is immutable after creation. Renewal is exclusively
-// the act of producing one or more successor lots whose paths[].Path
-// matches the predecessor's, but whose UUID, creation_time,
-// expiration_time, and deletion_time are fresh.
+// The scheduler ONLY mints new lots. It never updates an existing lot's
+// reservation semantics (creation_time, expiration_time, deletion_time,
+// dedicated_GB and other quota fields are treated as immutable once a
+// lot is created). The xrootd-lotman purge plugin separately mutates
+// usage accounting (current_usage, current_files, etc.) on every
+// read/write — those mutations are orthogonal to the planner's
+// reservation set. Renewal is exclusively the act of producing one or
+// more successor lots whose paths[].Path matches the predecessor's,
+// but whose UUID, creation_time, expiration_time, and deletion_time
+// are fresh.
 //
 // ## Multi-fill within the horizon
 //
@@ -60,10 +65,10 @@
 //	                  capped overall at MaxLotLifetime
 //
 // Gaps narrower than Lotman.MinFillerWidth are left unfilled and a
-// SkipReason is emitted so operators can audit. The default value of
+// skipReason is emitted so operators can audit. The default value of
 // Lotman.MinFillerWidth is 0, which means every gap is filled.
 //
-// ## Horizon refusal
+// ## Horizon refusal (and successor lifetime vs horizon)
 //
 // Successors whose computed creation_time falls beyond now+SchedulingHorizon
 // are NOT minted on this tick; they will be planned on a future tick once
@@ -71,11 +76,32 @@
 // scheduling decisions tied to a meaningful look-ahead window and lets the
 // system absorb federation-ad churn before committing to a new reservation.
 //
-// ## Parent clamping (axiom 3)
+// If the successor's creation_time is inside the horizon but its
+// DefaultLotExpirationLifetime would push expiration_time past it, the
+// lot IS created with the FULL default lifetime (not clipped to the
+// horizon end). The horizon bounds when a lot is _started_, not when it
+// ends — once the planner has committed to a successor, the rest of
+// its window is determined by DefaultLotExpirationLifetime, the
+// effective parent's expiration_time, and MaxLotLifetime.
+//
+// ## Race conditions with external reservations
+//
+// The planner takes a snapshot of `existing` lots at tick start. If an
+// external API (anything other than this planner) creates a lot between
+// the snapshot and our CreateLot calls, lotman's strict_hierarchy
+// enforcement may reject our proposal. CreateLot errors are logged and
+// skipped; the next tick's snapshot will see the new lot and the
+// planner naturally converges. Today Pelican only mints lots from this
+// scheduler, so this is mainly a defensive note for future external
+// callers; a lotman-side advisory lock per path could be added if this
+// becomes a real problem.
+//
+// ## Parent clamping (lotman "axiom 3": child time window ⊆ parent)
 //
 // Each successor's window is clipped to the effective parent segment
-// active at the would-be creation_time, so lotman's axiom 3 always
-// holds:
+// active at the would-be creation_time, so lotman's third axiom
+// always holds. In Pelican-internal terms: a child lot may not be
+// active outside the lifetime of its parent.
 //
 //	child.creation_time   ≥ parent.creation_time
 //	child.expiration_time ≤ parent.expiration_time
@@ -102,8 +128,11 @@
 // where divisor_e is N+1 for top-level paths (sharing root's pool with
 // no reserve) and N+2 for deeper paths (one extra share kept by the
 // parent as reserve, matching lot_tree.go::distribute). Taking the
-// minimum across epochs guarantees axiom 1 (Σ children ≤ parent) holds
-// at every instant the successor will exist. See epoch.go for details.
+// minimum across epochs guarantees lotman's first axiom —
+// Σ children.dedicated_GB ≤ parent.dedicated_GB — holds at every
+// instant the successor will exist. (See lotman's documentation on
+// hierarchical quota invariants for the formal statement.)
+// See epoch.go for details.
 //
 // ## Lot names
 //
@@ -112,13 +141,13 @@
 // # Lot garbage collector (LaunchLotGcRoutine)
 //
 // Lots whose deletion_time has been in the past for at least
-// Lotman.LotRetention (default 60 days) can be physically removed from
+// Lotman.LotRecordRetention (default 60 days) can be physically removed from
 // the lotman database. This is the only code path in Pelican that ever
 // calls lotman_remove_lot. A lot is assumed to have been reclaimed by
 // the storage layer at or before its deletion_time, so deletion_time
 // alone is the GC trigger:
 //
-//	GC if now − deletion_time ≥ LotRetention
+//	GC if now − deletion_time ≥ LotRecordRetention
 //
 // The retention window gives operators a forensics window during which
 // historical lot metadata is still inspectable. The GC routine runs at
@@ -149,14 +178,14 @@ import (
 // coverage to decay).
 var renewalSawAdsOnce atomic.Bool
 
-// SkipReason explains why a particular renewal action was not taken.
-// Returned in RenewalProposal.Skips so callers (and tests) can audit.
-type SkipReason struct {
+// skipReason explains why a particular renewal action was not taken.
+// Returned in renewalProposal.skips so callers (and tests) can audit.
+type skipReason struct {
 	NamespacePath string
 	Reason        string
 }
 
-// RenewalProposal is the fully-precomputed action set the renewal
+// renewalProposal is the fully-precomputed action set the renewal
 // scheduler will apply on a single tick. Splitting "decide" from "apply"
 // keeps the scheduler unit-testable and lets the caller log/audit the
 // plan before committing.
@@ -164,9 +193,9 @@ type SkipReason struct {
 // The planner only ever proposes new lots. It never proposes mutations
 // of existing lots — every reservation is immutable after creation, and
 // the way to keep coverage going is to mint a fresh successor.
-type RenewalProposal struct {
-	NewLots []Lot
-	Skips   []SkipReason
+type renewalProposal struct {
+	newLots []Lot
+	skips   []skipReason
 }
 
 // renewalConfig captures the tunables threaded into the pure scheduler.
@@ -190,8 +219,8 @@ type renewalConfig struct {
 
 // renewExpiringLots is the pure planner used by LaunchRenewalRoutine.
 // It receives the federation's current namespace ads and the full set of
-// existing lots (typically obtained via listAllLotsFull) and produces a
-// RenewalProposal describing what should change. No FFI calls happen
+// existing lots (typically obtained via getActiveLotsForRenewal) and produces a
+// renewalProposal describing what should change. No FFI calls happen
 // here, so the planner is unit-testable with synthetic Lot slices.
 //
 // # Multi-fill semantics
@@ -235,11 +264,11 @@ type renewalConfig struct {
 // The planner does NOT extend existing lots. Every lot is immutable
 // after creation; renewal is exclusively the job of minting fresh
 // successors.
-func renewExpiringLots(cfg renewalConfig, fedAds []server_structs.NamespaceAdV2, existing []Lot) RenewalProposal {
-	prop := RenewalProposal{}
+func renewExpiringLots(cfg renewalConfig, fedAds []server_structs.NamespaceAdV2, existing []Lot) renewalProposal {
+	prop := renewalProposal{}
 
 	if cfg.PeriodMs <= 0 || cfg.DefaultLifetimeMs <= 0 {
-		prop.Skips = append(prop.Skips, SkipReason{Reason: "period or default lifetime <= 0"})
+		prop.skips = append(prop.skips, skipReason{Reason: "period or default lifetime <= 0"})
 		return prop
 	}
 	if cfg.MaxLifetimeMs > 0 && cfg.DefaultLifetimeMs > cfg.MaxLifetimeMs {
@@ -329,7 +358,7 @@ func renewExpiringLots(cfg renewalConfig, fedAds []server_structs.NamespaceAdV2,
 				// The parent will have no live lot at `create`.
 				// Advance past this hole; perhaps the next hole
 				// (after the next existing same-path lot) is covered.
-				prop.Skips = append(prop.Skips, SkipReason{
+				prop.skips = append(prop.skips, skipReason{
 					NamespacePath: p,
 					Reason:        "no parent segment covers candidate creation_time; deferring",
 				})
@@ -369,7 +398,7 @@ func renewExpiringLots(cfg renewalConfig, fedAds []server_structs.NamespaceAdV2,
 				continue
 			}
 			if cfg.MinFillerWidthMs > 0 && width < cfg.MinFillerWidthMs {
-				prop.Skips = append(prop.Skips, SkipReason{
+				prop.skips = append(prop.skips, skipReason{
 					NamespacePath: p,
 					Reason:        "filler width below Lotman.MinFillerWidth; default lot will absorb the gap",
 				})
@@ -396,21 +425,31 @@ func renewExpiringLots(cfg renewalConfig, fedAds []server_structs.NamespaceAdV2,
 				del = expire
 			}
 
+			// Lotman's new_lot_schema requires opportunistic_GB and
+			// max_num_objects to be present on every CreateLot call,
+			// even though Pelican does not currently manage either
+			// axis. Stamp the unbounded sentinel (-1) so the schema
+			// is satisfied without imposing a real cap; if/when
+			// Pelican grows policy for these axes the allocator can
+			// overwrite these defaults before apply.
+			unboundedOpp := float64(-1)
 			newLot := Lot{
 				LotName: uuid.NewString(),
 				Owner:   issuer,
 				// Parent UUID is filled in by the apply step.
 				Paths: []LotPath{{Path: p, Recursive: true}},
 				MPA: &MPA{
-					CreationTime:   &Int64FromFloat{Value: create},
-					ExpirationTime: &Int64FromFloat{Value: expire},
-					DeletionTime:   &Int64FromFloat{Value: del},
-					// Storage quotas are stamped by allocateEpochAwareQuotas
+					CreationTime:    &Int64FromFloat{Value: create},
+					ExpirationTime:  &Int64FromFloat{Value: expire},
+					DeletionTime:    &Int64FromFloat{Value: del},
+					OpportunisticGB: &unboundedOpp,
+					MaxNumObjects:   &Int64FromFloat{Value: -1},
+					// dedicated_GB is stamped by allocateEpochAwareQuotas
 					// after every path's timing has been planned.
 				},
 			}
-			prop.NewLots = append(prop.NewLots, newLot)
-			ref := &prop.NewLots[len(prop.NewLots)-1]
+			prop.newLots = append(prop.newLots, newLot)
+			ref := &prop.newLots[len(prop.newLots)-1]
 			plannedByPath[p] = append(plannedByPath[p], ref)
 
 			// Advance cursor past the just-planned successor. Continue
@@ -507,6 +546,14 @@ func parentNamespacePath(path string, existing []Lot, planned map[string][]*Lot)
 		if c == target {
 			return
 		}
+		// The synthetic root lot owns "/" (which normalises to "")
+		// and is non-expiring; treat it as "no real parent" so the
+		// planner falls into its top-level branch (empty timeline,
+		// no axiom-3 clamp) instead of looking for a parent segment
+		// that does not exist.
+		if c == "" || c == "/" {
+			return
+		}
 		if pathContains(c, target) && len(c) > bestLen {
 			bestPath = c
 			bestLen = len(c)
@@ -599,24 +646,10 @@ func LaunchRenewalRoutine(ctx context.Context, getNamespaceAds func() []server_s
 	if interval <= 0 {
 		interval = time.Hour
 	}
-	// Startup-time validation of Lotman.SchedulingHorizon. The runtime
-	// planner will defensively clamp again, but doing it here lets the
-	// operator see one warning at boot rather than one warning per tick
-	// for the lifetime of the process. Clamping is "up": shrinking
-	// horizon below DefaultLotExpirationLifetime makes every tick mint
-	// a lot whose end exceeds the horizon, and shrinking it below the
-	// tick interval causes the planner to keep re-minting the same
-	// lots back-to-back.
-	horizon := param.Lotman_SchedulingHorizon.GetDuration()
-	defLife := param.Lotman_DefaultLotExpirationLifetime.GetDuration()
-	if horizon > 0 && defLife > 0 && horizon < defLife {
-		log.Warnf("Lotman.SchedulingHorizon (%s) is shorter than Lotman.DefaultLotExpirationLifetime (%s); the planner will treat the horizon as %s. Consider raising Lotman.SchedulingHorizon to at least Lotman.DefaultLotExpirationLifetime.",
-			horizon, defLife, defLife)
-	}
-	if horizon > 0 && horizon < interval {
-		log.Warnf("Lotman.SchedulingHorizon (%s) is shorter than Lotman.RenewalCheckInterval (%s); the planner will treat the horizon as %s. Consider raising Lotman.SchedulingHorizon to at least Lotman.RenewalCheckInterval.",
-			horizon, interval, interval)
-	}
+	// SchedulingHorizon validation runs at config load
+	// (config/config.go); the runtime planner additionally clamps
+	// defensively per-tick so a stale config can't produce a coverage
+	// gap.
 	go func() {
 		log.Infof("Starting Lotman renewal routine; interval=%s", interval)
 		ticker := time.NewTicker(interval)
@@ -653,6 +686,18 @@ func LaunchRenewalRoutine(ctx context.Context, getNamespaceAds func() []server_s
 //     `successorCreate`.
 //  4. If no ancestor covers `successorCreate`, attach to "root". This is
 //     the same branch first-ever lots take.
+//
+// Worked example. We are choosing a parent for a successor on
+// `/a/b/c` whose creation_time is `*` below. The two candidate
+// ancestors are `/a/b` and `/a`; only `/a/b` has a planned-this-tick
+// successor, while `/a` has only an existing lot that covers `*`:
+//
+//	time →                     *
+//	/a/b/c (successor)         [---)
+//	/a/b   planned-this-tick   [-------)        ← chosen (rule 2)
+//	/a/b   existing            [---)            (does not cover *)
+//	/a     existing            [-------------)  (would match rule 3)
+//	root   ──always covers──   [────────────)   (rule 4 fallback)
 //
 // Pure / data-only: no FFI calls, safe to unit-test.
 func resolveSuccessorParent(path string, successorCreate int64, existing []Lot, planned map[string][]*Lot) string {
@@ -735,16 +780,20 @@ func runRenewalTick(getNamespaceAds func() []server_structs.NamespaceAdV2, perio
 		return
 	}
 
-	existing, err := listAllLotsFull()
+	nowMs := time.Now().UnixMilli()
+	horizonMs := param.Lotman_SchedulingHorizon.GetDuration().Milliseconds()
+
+	adPaths := dedupeNamespacePaths(ads)
+	existing, err := getActiveLotsForRenewal(adPaths, nowMs, nowMs+horizonMs)
 	if err != nil {
 		log.Warnf("Lotman renewal: failed to enumerate lots: %v", err)
 		return
 	}
 
 	cfg := renewalConfig{
-		NowMs:             time.Now().UnixMilli(),
+		NowMs:             nowMs,
 		PeriodMs:          period.Milliseconds(),
-		HorizonMs:         param.Lotman_SchedulingHorizon.GetDuration().Milliseconds(),
+		HorizonMs:         horizonMs,
 		MinFillerWidthMs:  param.Lotman_MinFillerWidth.GetDuration().Milliseconds(),
 		DefaultLifetimeMs: param.Lotman_DefaultLotExpirationLifetime.GetDuration().Milliseconds(),
 		DefaultDeletionMs: param.Lotman_DefaultLotDeletionLifetime.GetDuration().Milliseconds(),
@@ -754,7 +803,7 @@ func runRenewalTick(getNamespaceAds func() []server_structs.NamespaceAdV2, perio
 	}
 
 	prop := renewExpiringLots(cfg, ads, existing)
-	if len(prop.NewLots) == 0 {
+	if len(prop.newLots) == 0 {
 		log.Debug("Lotman renewal: nothing to do")
 		return
 	}
@@ -772,9 +821,9 @@ func runRenewalTick(getNamespaceAds func() []server_structs.NamespaceAdV2, perio
 	// resolver's `successorCreate` argument; planned-this-tick siblings
 	// → its `planned` map) is exercised by tests rather than relying on
 	// the call site being correct by inspection.
-	assignSuccessorParents(prop.NewLots, existing)
+	assignSuccessorParents(prop.newLots, existing)
 
-	for _, l := range prop.NewLots {
+	for _, l := range prop.newLots {
 		if err := CreateLot(&l, federationIssuer); err != nil {
 			log.Warnf("Lotman renewal: failed to create lot for %q: %v", l.Paths[0].Path, err)
 		} else {
@@ -815,7 +864,7 @@ func assignSuccessorParents(newLots []Lot, existing []Lot) {
 }
 
 // LaunchLotGcRoutine starts a background ticker that periodically removes
-// lots whose deletion_time + LotRetention has passed. It returns
+// lots whose deletion_time + LotRecordRetention has passed. It returns
 // immediately; the goroutine exits when ctx is done. The cadence is
 // fixed at 24 hours.
 func LaunchLotGcRoutine(ctx context.Context) {
@@ -896,7 +945,7 @@ const (
 	gcOverridePolicy     = false
 )
 
-// runGcTick removes any lot whose deletion_time was at least LotRetention
+// runGcTick removes any lot whose deletion_time was at least LotRecordRetention
 // ago. Failures are logged and swallowed.
 func runGcTick() {
 	federationIssuer, err := getFederationIssuer()
@@ -904,15 +953,13 @@ func runGcTick() {
 		log.Warnf("Lotman GC: cannot determine federation issuer; skipping tick: %v", err)
 		return
 	}
-	retention := param.Lotman_LotRetention.GetDuration()
+	retention := param.Lotman_LotRecordRetention.GetDuration()
 
-	existing, err := listAllLotsFull()
+	names, err := getGcCandidates(time.Now().UnixMilli(), retention)
 	if err != nil {
-		log.Warnf("Lotman GC: failed to enumerate lots: %v", err)
+		log.Warnf("Lotman GC: failed to enumerate GC candidates: %v", err)
 		return
 	}
-
-	names := gcEligibleLots(existing, time.Now().UnixMilli(), retention)
 	for _, name := range names {
 		if err := RemoveLot(name, gcReassignOrphans, gcReassignNonOrphans, gcAssignPolicy, gcOverridePolicy, federationIssuer); err != nil {
 			log.Warnf("Lotman GC: failed to remove lot %s: %v", name, err)

--- a/lotman/renewal.go
+++ b/lotman/renewal.go
@@ -938,6 +938,33 @@ func gcEligibleLots(existing []Lot, nowMs int64, retention time.Duration) []stri
 // cascade does not orphan downstream lots) and the latter two false
 // (we are not propagating policy and never want to override safety
 // checks on a routine GC).
+//
+// On the option of collapsing this loop into a single recursive
+// subtree delete: under strict_hierarchy lotman enforces
+// child.deletion_time ≤ parent.deletion_time, so any past-deletion
+// parent transitively implies all of its descendants are also past-
+// deletion. That means lotman_remove_lots_recursive on each subtree
+// root in `names` would, in principle, delete the same set without
+// needing orphan reassignment. We deliberately keep the per-lot loop
+// for three reasons:
+//
+//  1. Per-lot logging is operationally valuable — each removed lot
+//     gets its own audit line, which simplifies forensics when a lot
+//     disappears unexpectedly.
+//  2. Detecting "subtree roots" inside `names` is itself extra logic
+//     (group by parent_uuid, drop entries whose parent is also in the
+//     set) that offsets most of the simplification, and it has to be
+//     redone every tick.
+//  3. assignLTBRParentsToOrphans=true keeps GC correct even if some
+//     future external lot writer (or a transient invariant violation)
+//     ever lands a non-past-deletion child under a past-deletion
+//     parent. The recursive form would happily sweep that child away.
+//     The defensive cost is a few extra FFI calls per tick on what is
+//     already a daily cadence.
+//
+// If lotman ever exposes a "remove all lots whose deletion_time +
+// retention ≤ now" primitive (lotman-side equivalent of getGcCandidates
+// + RemoveLot fused into one C call), revisit this loop.
 const (
 	gcReassignOrphans    = true
 	gcReassignNonOrphans = true
@@ -947,6 +974,16 @@ const (
 
 // runGcTick removes any lot whose deletion_time was at least LotRecordRetention
 // ago. Failures are logged and swallowed.
+//
+// Concurrency note: this is the only Pelican code path that calls
+// RemoveLot. Pelican does not currently expose any user-facing API
+// (HTTP, CLI, or otherwise) that creates, updates, or deletes lots
+// outside the renewal scheduler and this GC, so there is no in-process
+// race to worry about today. If a future PR adds such an API — for
+// example, an operator endpoint to mint or rescind reservations —
+// concurrent writers may race against this tick (and against
+// runRenewalTick) at the lotman C layer. lotman currently exposes no
+// per-path advisory lock
 func runGcTick() {
 	federationIssuer, err := getFederationIssuer()
 	if err != nil || federationIssuer == "" {
@@ -987,8 +1024,8 @@ func validateLotLifetime(l *Lot) error {
 	span := l.MPA.ExpirationTime.Value - l.MPA.CreationTime.Value
 	if span > maxLifetime {
 		return errors.Errorf(
-			"lot %s expiration_time exceeds Lotman.MaxLotLifetime (%dms requested, max %dms)",
-			l.LotName, span, maxLifetime)
+			"lot %s expiration_time exceeds %s (%dms requested, max %dms)",
+			l.LotName, param.Lotman_MaxLotLifetime.GetName(), span, maxLifetime)
 	}
 	return nil
 }

--- a/lotman/renewal_test.go
+++ b/lotman/renewal_test.go
@@ -1,0 +1,924 @@
+//go:build linux && !ppc64le
+
+/***************************************************************
+*
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+***************************************************************/
+
+package lotman
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+func adsForRenewal(paths ...string) []server_structs.NamespaceAdV2 {
+	issuerURL, _ := url.Parse("https://issuer.example/")
+	out := make([]server_structs.NamespaceAdV2, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, server_structs.NamespaceAdV2{
+			Path: p,
+			Issuer: []server_structs.TokenIssuer{
+				{IssuerUrl: *issuerURL},
+			},
+		})
+	}
+	return out
+}
+
+func defaultRenewalCfg(now int64) renewalConfig {
+	// Legacy single-fill-style cfg used by the original tests:
+	// Horizon == DefaultLifetime == Period so each path mints at most
+	// one successor per tick, matching the pre-multi-fill semantics
+	// those tests were written against. The planner will defensively
+	// clamp Horizon up to DefaultLifetime; setting them equal keeps
+	// behaviour predictable.
+	return renewalConfig{
+		NowMs:             now,
+		PeriodMs:          int64(60 * 60 * 1000), // 1h
+		HorizonMs:         int64(60 * 60 * 1000), // 1h
+		DefaultLifetimeMs: int64(60 * 60 * 1000), // 1h
+		DefaultDeletionMs: int64(60 * 60 * 1000),
+		MaxLifetimeMs:     int64(168 * 60 * 60 * 1000), // 168h
+		FederationIssuer:  "https://fed.example/",
+	}
+}
+
+func TestRenewExpiringLots_NoExistingLots_MintsForEveryNamespace(t *testing.T) {
+	now := int64(1_000_000)
+	cfg := defaultRenewalCfg(now)
+	ads := adsForRenewal("/a", "/b")
+
+	prop := renewExpiringLots(cfg, ads, nil)
+	require.Len(t, prop.NewLots, 2)
+
+	got := map[string]bool{}
+	for _, l := range prop.NewLots {
+		require.NotEmpty(t, l.LotName, "new lots must have a UUID name")
+		require.Len(t, l.Paths, 1)
+		got[l.Paths[0].Path] = true
+		assert.Equal(t, now, l.MPA.CreationTime.Value)
+		assert.Equal(t, now+cfg.DefaultLifetimeMs, l.MPA.ExpirationTime.Value)
+	}
+	assert.True(t, got["/a"])
+	assert.True(t, got["/b"])
+}
+
+func TestRenewExpiringLots_CoverageInsidePeriod_NoNewLot(t *testing.T) {
+	now := int64(1_000_000)
+	cfg := defaultRenewalCfg(now)
+	ads := adsForRenewal("/a")
+
+	// Existing lot covers [now-1h, now+24h) -> no gap inside [now, now+1h).
+	existing := []Lot{makeLot("u1", "/a", now-int64(60*60*1000), now+int64(24*60*60*1000))}
+	prop := renewExpiringLots(cfg, ads, existing)
+	assert.Empty(t, prop.NewLots)
+}
+
+func TestRenewExpiringLots_GapAtNow_MintsSuccessor(t *testing.T) {
+	now := int64(10_000_000)
+	cfg := defaultRenewalCfg(now)
+	ads := adsForRenewal("/a")
+	// Existing lot expired before now; coverage should restart at now.
+	existing := []Lot{makeLot("u1", "/a", 0, now-1)}
+	prop := renewExpiringLots(cfg, ads, existing)
+	require.Len(t, prop.NewLots, 1)
+	assert.Equal(t, now, prop.NewLots[0].MPA.CreationTime.Value)
+}
+
+func TestRenewExpiringLots_GapInsidePeriod_CreationAtPredecessorExpiration(t *testing.T) {
+	now := int64(10_000_000)
+	cfg := defaultRenewalCfg(now)
+	ads := adsForRenewal("/a")
+	predExp := now + int64(30*60*1000) // expires in 30 min, inside the 1h window.
+	existing := []Lot{makeLot("u1", "/a", now-1000, predExp)}
+	prop := renewExpiringLots(cfg, ads, existing)
+	require.Len(t, prop.NewLots, 1)
+	// New lot must start at the predecessor's expiration to avoid overlap.
+	assert.Equal(t, predExp, prop.NewLots[0].MPA.CreationTime.Value)
+}
+
+func TestRenewExpiringLots_MonitoringPathSkipped(t *testing.T) {
+	now := int64(1_000_000)
+	cfg := defaultRenewalCfg(now)
+	ads := adsForRenewal("/a", "/pelican/monitoring/probe")
+	prop := renewExpiringLots(cfg, ads, nil)
+	require.Len(t, prop.NewLots, 1)
+	assert.Equal(t, "/a", prop.NewLots[0].Paths[0].Path)
+}
+
+func TestRenewExpiringLots_Idempotent(t *testing.T) {
+	now := int64(1_000_000)
+	cfg := defaultRenewalCfg(now)
+	ads := adsForRenewal("/a")
+
+	first := renewExpiringLots(cfg, ads, nil)
+	require.Len(t, first.NewLots, 1)
+
+	// Second pass: feed the freshly-minted lot back as existing.
+	second := renewExpiringLots(cfg, ads, first.NewLots)
+	assert.Empty(t, second.NewLots)
+}
+
+func TestRenewExpiringLots_LifetimeClampedToMax(t *testing.T) {
+	now := int64(1_000_000)
+	cfg := defaultRenewalCfg(now)
+	cfg.DefaultLifetimeMs = 2 * cfg.MaxLifetimeMs
+	ads := adsForRenewal("/a")
+	prop := renewExpiringLots(cfg, ads, nil)
+	require.Len(t, prop.NewLots, 1)
+	span := prop.NewLots[0].MPA.ExpirationTime.Value - prop.NewLots[0].MPA.CreationTime.Value
+	assert.Equal(t, cfg.MaxLifetimeMs, span)
+}
+
+func TestRenewExpiringLots_EmptyConfig_NoOp(t *testing.T) {
+	cfg := renewalConfig{NowMs: 0, PeriodMs: 0, DefaultLifetimeMs: 0}
+	prop := renewExpiringLots(cfg, adsForRenewal("/a"), nil)
+	assert.Empty(t, prop.NewLots)
+	assert.NotEmpty(t, prop.Skips)
+}
+
+// Axiom-3 clamping: a child successor whose default lifetime would exceed
+// its parent's existing-lot expiration must be clamped to the parent's
+// window so lotman accepts it. The child's lifetime is therefore shorter,
+// and the next renewal tick will mint a new child once the parent has
+// renewed.
+func TestRenewExpiringLots_ChildClampedToExistingParentExpiration(t *testing.T) {
+	now := int64(10_000_000)
+	cfg := defaultRenewalCfg(now)
+	// Use DefaultLifetime > parent's remaining 2h window so the child
+	// successor's expiration must be clamped down. Horizon is set
+	// equal to DefaultLifetime so the planner doesn't bump it up
+	// defensively.
+	cfg.DefaultLifetimeMs = int64(4 * 60 * 60 * 1000) // 4h
+	cfg.HorizonMs = cfg.DefaultLifetimeMs
+	ads := adsForRenewal("/a", "/a/b")
+
+	// /a has an existing lot whose expiration is much earlier than
+	// /a/b's default 4h window would extend to.
+	parentExp := now + int64(2*60*60*1000) // /a expires in 2h
+	parentLot := makeLot("u-parent", "/a", now-1000, parentExp)
+	parentLot.MPA.DeletionTime = &Int64FromFloat{Value: parentExp}
+	existing := []Lot{parentLot}
+	prop := renewExpiringLots(cfg, ads, existing)
+
+	// Find the FIRST /a/b successor — it must be clamped to the
+	// existing parent's window.
+	var child *Lot
+	for i := range prop.NewLots {
+		if prop.NewLots[i].Paths[0].Path == "/a/b" {
+			child = &prop.NewLots[i]
+			break
+		}
+	}
+	require.NotNil(t, child, "expected a successor for /a/b")
+	assert.Equal(t, now, child.MPA.CreationTime.Value)
+	assert.Equal(t, parentExp, child.MPA.ExpirationTime.Value,
+		"child's expiration must be clamped to existing parent's expiration (axiom 3)")
+	assert.LessOrEqual(t, child.MPA.DeletionTime.Value, parentExp,
+		"child's deletion_time must also fit inside parent's deletion_time")
+}
+
+// When both parent and child are being renewed in the same tick, the
+// child must be clamped against the FRESH successor's window (not the
+// stale predecessor's). The parent is processed first by virtue of
+// shortest-path-first ordering.
+func TestRenewExpiringLots_ChildClampedToPlannedParentSuccessor(t *testing.T) {
+	now := int64(10_000_000)
+	cfg := defaultRenewalCfg(now)
+
+	ads := adsForRenewal("/a", "/a/b")
+	// Both lots already past their expiration, so both will renew this tick.
+	existing := []Lot{
+		makeLot("u-parent", "/a", now-int64(60*60*1000), now-1000),
+		makeLot("u-child", "/a/b", now-int64(60*60*1000), now-1000),
+	}
+	prop := renewExpiringLots(cfg, ads, existing)
+	require.Len(t, prop.NewLots, 2)
+
+	var parent, child Lot
+	for _, l := range prop.NewLots {
+		if l.Paths[0].Path == "/a" {
+			parent = l
+		} else {
+			child = l
+		}
+	}
+	require.NotNil(t, parent.MPA)
+	require.NotNil(t, child.MPA)
+	// Both windows should be identical (same default lifetime, same
+	// creation_time of `now`), satisfying axiom 3 with equality on the
+	// expiration boundary.
+	assert.Equal(t, parent.MPA.CreationTime.Value, child.MPA.CreationTime.Value)
+	assert.Equal(t, parent.MPA.ExpirationTime.Value, child.MPA.ExpirationTime.Value)
+	assert.LessOrEqual(t, child.MPA.ExpirationTime.Value, parent.MPA.ExpirationTime.Value)
+}
+
+// If the parent's effective window is already in the past (parent
+// expired and its successor is not yet planned for some reason), the
+// child cannot be minted with a positive window and must be skipped
+// rather than violating axiom 3. The next tick will catch up after the
+// parent has been renewed.
+func TestRenewExpiringLots_SkippedWhenParentWindowGivesNoRoom(t *testing.T) {
+	now := int64(10_000_000)
+	cfg := defaultRenewalCfg(now)
+	// Only /a/b is advertised — /a is an "implicit" parent path with a
+	// historical lot but no current ad, so it won't be renewed.
+	ads := adsForRenewal("/a/b")
+	existing := []Lot{
+		makeLot("u-parent-old", "/a", now-int64(2*60*60*1000), now-1000), // expired
+	}
+	prop := renewExpiringLots(cfg, ads, existing)
+	assert.Empty(t, prop.NewLots, "child cannot fit inside an already-expired parent window")
+	require.NotEmpty(t, prop.Skips)
+	assert.Equal(t, "/a/b", prop.Skips[0].NamespacePath)
+}
+
+// horizonRenewalCfg returns a renewalConfig with the new
+// SchedulingHorizon / MinFillerWidth knobs set to plausible values so
+// the multi-fill code path is exercised end-to-end without falling back
+// to the legacy single-fill defaults.
+func horizonRenewalCfg(now int64) renewalConfig {
+	return renewalConfig{
+		NowMs:             now,
+		PeriodMs:          int64(60 * 60 * 1000),       // 1h
+		HorizonMs:         int64(48 * 60 * 60 * 1000),  // 48h
+		MinFillerWidthMs:  int64(15 * 60 * 1000),       // 15m
+		DefaultLifetimeMs: int64(24 * 60 * 60 * 1000),  // 24h
+		DefaultDeletionMs: int64(48 * 60 * 60 * 1000),  // 48h
+		MaxLifetimeMs:     int64(168 * 60 * 60 * 1000), // 168h
+		FederationIssuer:  "https://fed.example/",
+	}
+}
+
+// Multi-fill: a path with three discrete holes inside the horizon must
+// produce three successors on a single tick.
+func TestRenewExpiringLots_MultiFillFillsEveryHoleInsideHorizon(t *testing.T) {
+	const (
+		hour = int64(60 * 60 * 1000)
+	)
+	now := int64(100 * hour)
+	cfg := horizonRenewalCfg(now)
+	ads := adsForRenewal("/a")
+
+	// Existing lots create three internal holes inside [now, now+48h):
+	//   [now, now+5h)            covered by L1
+	//   [now+5h, now+10h)        HOLE
+	//   [now+10h, now+12h)       covered by L2
+	//   [now+12h, now+30h)       HOLE
+	//   [now+30h, now+33h)       covered by L3
+	//   [now+33h, now+48h)       HOLE (extends past end-of-horizon)
+	existing := []Lot{
+		makeLot("L1", "/a", now-hour, now+5*hour),
+		makeLot("L2", "/a", now+10*hour, now+12*hour),
+		makeLot("L3", "/a", now+30*hour, now+33*hour),
+	}
+	prop := renewExpiringLots(cfg, ads, existing)
+	require.Len(t, prop.NewLots, 3, "three internal holes must yield three successors")
+
+	// Each successor must start at its hole's left edge and end no
+	// later than the hole's right edge (no overlap with existing lots).
+	for _, l := range prop.NewLots {
+		create := l.MPA.CreationTime.Value
+		expire := l.MPA.ExpirationTime.Value
+		assert.GreaterOrEqual(t, create, now)
+		assert.Less(t, create, expire)
+		// Successor must not overlap any of the existing lots.
+		for _, e := range existing {
+			ec := e.MPA.CreationTime.Value
+			ee := e.MPA.ExpirationTime.Value
+			overlap := create < ee && ec < expire
+			assert.False(t, overlap,
+				"new lot [%d,%d) overlaps existing [%d,%d)", create, expire, ec, ee)
+		}
+	}
+}
+
+// Gap trimming: a successor whose default lifetime would extend past
+// the next existing lot must have its expiration_time clamped to the
+// hole's right edge.
+func TestRenewExpiringLots_GapTrimmingClampsExpirationToHoleEnd(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+	cfg := horizonRenewalCfg(now)
+	// Narrow horizon to just the first hole so the post-existing-lot
+	// hole [now+25h, ∞) is deferred to a future tick.
+	cfg.HorizonMs = 2 * hour
+	cfg.DefaultLifetimeMs = 24 * hour
+	ads := adsForRenewal("/a")
+
+	// One small hole [now, now+2h), a 24h-default successor would
+	// otherwise spill into the next existing lot starting at now+2h.
+	existing := []Lot{
+		makeLot("L-future", "/a", now+2*hour, now+25*hour),
+	}
+	prop := renewExpiringLots(cfg, ads, existing)
+	require.Len(t, prop.NewLots, 1)
+	got := prop.NewLots[0]
+	assert.Equal(t, now, got.MPA.CreationTime.Value)
+	assert.Equal(t, now+2*hour, got.MPA.ExpirationTime.Value,
+		"expiration must be trimmed to hole_end to avoid same-path overlap")
+}
+
+// Horizon refusal: holes that begin past the horizon must NOT be filled
+// on this tick. They will be picked up on a later tick once the
+// horizon slides forward.
+func TestRenewExpiringLots_HorizonRefusal_DefersHolesBeyondHorizon(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+	cfg := horizonRenewalCfg(now) // 48h horizon
+
+	ads := adsForRenewal("/a")
+	// Fully cover the horizon with one big lot, then leave a hole far in the future.
+	existing := []Lot{
+		makeLot("L-now", "/a", now-hour, now+50*hour), // covers [now, now+48h]
+	}
+	prop := renewExpiringLots(cfg, ads, existing)
+	assert.Empty(t, prop.NewLots, "no holes inside horizon → no successors")
+}
+
+// Narrow-gap skip: a hole strictly narrower than MinFillerWidth must be
+// recorded as a Skip rather than minted as a successor.
+func TestRenewExpiringLots_NarrowGapSkipped(t *testing.T) {
+	const (
+		hour   = int64(60 * 60 * 1000)
+		minute = int64(60 * 1000)
+	)
+	now := int64(100 * hour)
+	cfg := horizonRenewalCfg(now) // 15m MinFillerWidth
+	// Narrow horizon so only the sub-MinFillerWidth gap is in scope;
+	// the post-existing-lot hole [now+25h, ∞) lies past the horizon.
+	cfg.HorizonMs = 1 * hour
+	cfg.DefaultLifetimeMs = 1 * hour
+	ads := adsForRenewal("/a")
+	// 5-minute hole [now, now+5m) — narrower than MinFillerWidth=15m.
+	existing := []Lot{
+		makeLot("L-future", "/a", now+5*minute, now+25*hour),
+	}
+	prop := renewExpiringLots(cfg, ads, existing)
+	assert.Empty(t, prop.NewLots, "sub-MinFillerWidth gap must not be filled")
+	require.NotEmpty(t, prop.Skips)
+	found := false
+	for _, s := range prop.Skips {
+		if s.NamespacePath == "/a" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected a Skip for /a")
+}
+
+// Epoch-aware quota allocation: with N top-level paths and a known
+// root capacity, every freshly-minted lot should be stamped with
+// rootDedicatedGB / N (top-level uses no reserve, matching
+// lot_tree.go::distribute).
+func TestAllocateEpochAwareQuotas_TopLevelEqualShare(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+	cfg := horizonRenewalCfg(now)
+	cfg.HorizonMs = 24 * hour // exactly one fill per path
+	cfg.DefaultLifetimeMs = 24 * hour
+	cfg.RootDedicatedGB = 1000.0
+	ads := adsForRenewal("/a", "/b", "/c") // three siblings under root
+
+	prop := renewExpiringLots(cfg, ads, nil)
+	require.Len(t, prop.NewLots, 3)
+
+	allocateEpochAwareQuotas(&prop, nil, ads, cfg)
+
+	// Top-level divisor = N = 3, share = 1000/3 ≈ 333.33.
+	want := 1000.0 / 3.0
+	for _, l := range prop.NewLots {
+		require.NotNil(t, l.MPA.DedicatedGB, "lot %s missing dedicated_GB", l.LotName)
+		assert.InDelta(t, want, *l.MPA.DedicatedGB, 0.01,
+			"lot %s for %q got %.2f, want ~%.2f",
+			l.LotName, l.Paths[0].Path, *l.MPA.DedicatedGB, want)
+	}
+}
+
+// Epoch-aware quota allocation with no root capacity falls back to
+// stamping zero (so the lot still exists but promises nothing).
+func TestAllocateEpochAwareQuotas_NoRootCapacity_StampsZero(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+	cfg := horizonRenewalCfg(now)
+	cfg.HorizonMs = 24 * hour
+	cfg.DefaultLifetimeMs = 24 * hour
+	cfg.RootDedicatedGB = 0 // unknown / unset
+	ads := adsForRenewal("/a")
+
+	prop := renewExpiringLots(cfg, ads, nil)
+	require.Len(t, prop.NewLots, 1)
+	allocateEpochAwareQuotas(&prop, nil, ads, cfg)
+	require.NotNil(t, prop.NewLots[0].MPA.DedicatedGB)
+	assert.Equal(t, 0.0, *prop.NewLots[0].MPA.DedicatedGB)
+}
+
+// rootDedicatedGB pulls the dedicated_GB off the root lot in the
+// existing snapshot. When no root lot is present, returns 0.
+func TestRootDedicatedGB(t *testing.T) {
+	v := 4096.0
+	root := Lot{
+		LotName: "root",
+		MPA:     &MPA{DedicatedGB: &v},
+	}
+	other := makeLot("u1", "/x", 0, 1000)
+	assert.Equal(t, 4096.0, rootDedicatedGB([]Lot{other, root}))
+	assert.Equal(t, 0.0, rootDedicatedGB([]Lot{other}))
+}
+
+// makeLotWithDed is a test helper that builds a Lot with explicit
+// CreationTime/ExpirationTime/DedicatedGB so the epoch allocator can
+// see "already-promised bytes" from existing siblings.
+func makeLotWithDed(name, path string, create, expire int64, ded float64) Lot {
+	d := ded
+	return Lot{
+		LotName: name,
+		Paths:   []LotPath{{Path: path, Recursive: true}},
+		MPA: &MPA{
+			CreationTime:   &Int64FromFloat{Value: create},
+			ExpirationTime: &Int64FromFloat{Value: expire},
+			DedicatedGB:    &d,
+		},
+	}
+}
+
+// Regression for the parent-attachment bug: when a parent and its
+// child are both renewed in the same tick, the new child must attach to
+// the NEW parent, not the now-expired old parent. The old behaviour
+// inherited Parents[0] from the predecessor lot, which still pointed at
+// the soon-to-be-reclaimed old parent UUID — failing axiom 3 at
+// admission and orphaning the new child once the old parent was GC'd.
+func TestResolveSuccessorParent_PrefersPlannedParentOverExpiredExisting(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+
+	// Existing world: parent /a and child /a/b both expired in the past.
+	parentOld := makeLot("uuid-parent-old", "/a", now-2*hour, now-hour)
+	childOld := makeLot("uuid-child-old", "/a/b", now-2*hour, now-hour)
+	childOld.Parents = []string{parentOld.LotName}
+	existing := []Lot{parentOld, childOld}
+
+	// Planned world: brand-new successors for both, both starting at
+	// `now` and ending one default-lifetime later.
+	parentNew := makeLot("uuid-parent-new", "/a", now, now+hour)
+	childNew := makeLot("uuid-child-new", "/a/b", now, now+hour)
+	planned := map[string][]*Lot{
+		"/a":   {&parentNew},
+		"/a/b": {&childNew},
+	}
+
+	got := resolveSuccessorParent("/a/b", now, existing, planned)
+	assert.Equal(t, "uuid-parent-new", got,
+		"child must attach to the freshly-planned parent, not the expired old parent")
+}
+
+// When only the child is being renewed but the existing parent still
+// covers the child's creation_time, attach to the existing parent.
+func TestResolveSuccessorParent_FallsBackToExistingCoveringParent(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+
+	parent := makeLot("uuid-parent", "/a", now-hour, now+10*hour)
+	existing := []Lot{parent}
+	childNew := makeLot("uuid-child-new", "/a/b", now, now+hour)
+	planned := map[string][]*Lot{"/a/b": {&childNew}}
+
+	got := resolveSuccessorParent("/a/b", now, existing, planned)
+	assert.Equal(t, "uuid-parent", got)
+}
+
+// First-ever lot for a top-level path with no covering ancestor falls
+// back to "root".
+func TestResolveSuccessorParent_RootFallback(t *testing.T) {
+	got := resolveSuccessorParent("/a", 0, nil, nil)
+	assert.Equal(t, "root", got)
+}
+
+// Picks the deepest covering ancestor when both /a and /a/b have
+// covering lots and the new lot is /a/b/c.
+func TestResolveSuccessorParent_PicksDeepestCoveringAncestor(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+	a := makeLot("uuid-a", "/a", now-hour, now+10*hour)
+	ab := makeLot("uuid-ab", "/a/b", now-hour, now+10*hour)
+	existing := []Lot{a, ab}
+	got := resolveSuccessorParent("/a/b/c", now, existing, nil)
+	assert.Equal(t, "uuid-ab", got, "must pick the longest-prefix ancestor")
+}
+
+// Regression for the epoch-allocator double-counting bug: an existing
+// sibling at the top level was being subtracted from `parentCap` AND
+// added to the divisor, leaving capacity stranded. With root=1000 and
+// an existing /x holding 400, three new /a /b /c must each receive
+// (1000 − 400) / 3 = 200, not (1000 − 400) / 4 = 150.
+func TestAllocateEpochAwareQuotas_MixedExistingAndPlannedSiblings(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+	cfg := horizonRenewalCfg(now)
+	cfg.HorizonMs = 24 * hour
+	cfg.DefaultLifetimeMs = 24 * hour
+	cfg.RootDedicatedGB = 1000.0
+
+	// Existing sibling /x already has 400 GB stamped, covering the
+	// entire window of the new lots.
+	existing := []Lot{makeLotWithDed("uuid-x", "/x", now-hour, now+48*hour, 400.0)}
+
+	ads := adsForRenewal("/a", "/b", "/c", "/x")
+	prop := renewExpiringLots(cfg, ads, existing)
+	// /x is already covered by the existing lot inside the horizon, so
+	// the planner mints only the three new top-level paths.
+	require.Len(t, prop.NewLots, 3, "planner should mint /a, /b, /c (not /x)")
+
+	allocateEpochAwareQuotas(&prop, existing, ads, cfg)
+
+	want := (1000.0 - 400.0) / 3.0 // = 200
+	for _, l := range prop.NewLots {
+		require.NotNil(t, l.MPA.DedicatedGB)
+		assert.InDelta(t, want, *l.MPA.DedicatedGB, 0.01,
+			"lot %s for %q got %.2f, want %.2f (residual / nNew, not residual / (nNew+nExisting))",
+			l.LotName, l.Paths[0].Path, *l.MPA.DedicatedGB, want)
+	}
+}
+
+// Deeper-hierarchy divisor: when the parent /a has a stamped capacity
+// and we plan two new children /a/b and /a/c, each must receive
+// parent_capacity / (2 children + 1 parent reserve) = parent / 3 — the
+// N+2 rule (2 newcomers + self counted via N+1 in the allocator's
+// internal numbering, plus the parent reserve at deeper levels).
+func TestAllocateEpochAwareQuotas_DeeperHierarchyDivisor(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+	cfg := horizonRenewalCfg(now)
+	cfg.HorizonMs = 24 * hour
+	cfg.DefaultLifetimeMs = 24 * hour
+	cfg.RootDedicatedGB = 10000.0
+
+	// Existing parent /a with 900 GB stamped covering the full horizon.
+	parent := makeLotWithDed("uuid-a", "/a", now-hour, now+48*hour, 900.0)
+	existing := []Lot{parent}
+
+	ads := adsForRenewal("/a", "/a/b", "/a/c")
+	prop := renewExpiringLots(cfg, ads, existing)
+	// Only the two children are minted; /a is already covered.
+	require.Len(t, prop.NewLots, 2)
+
+	allocateEpochAwareQuotas(&prop, existing, ads, cfg)
+
+	// Parent has 900; two new children + 1 reserve share = 3-way split.
+	want := 900.0 / 3.0
+	for _, l := range prop.NewLots {
+		require.NotNil(t, l.MPA.DedicatedGB)
+		assert.InDelta(t, want, *l.MPA.DedicatedGB, 0.01,
+			"deeper-level lot %s for %q got %.2f, want %.2f (parent/3, leaving one reserve share)",
+			l.LotName, l.Paths[0].Path, *l.MPA.DedicatedGB, want)
+	}
+}
+
+// Multi-epoch: a new lot whose lifetime spans two epochs (sibling
+// active in the first half, gone in the second) must be stamped with
+// the SMALLER per-epoch share, so it is non-contracting in every
+// epoch it lives through. With root=1200, a planned peer /b active for
+// only the first half, the new lot /a sees:
+//   - epoch 1 [now, now+12h): nActiveNew=1 (peer /b), divisor=2, share=600
+//   - epoch 2 [now+12h, now+24h): nActiveNew=0, divisor=1, share=1200
+//
+// min-over-epochs = 600.
+func TestAllocateEpochAwareQuotas_MultiEpoch_MinShareWins(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+	cfg := horizonRenewalCfg(now)
+	cfg.HorizonMs = 24 * hour
+	cfg.DefaultLifetimeMs = 24 * hour
+	cfg.RootDedicatedGB = 1200.0
+
+	// Pre-seed a planned-this-tick peer /b that is active only for the
+	// first half of /a's window. We bypass the planner and inject the
+	// peer directly into prop.NewLots so we can control its window.
+	prop := RenewalProposal{}
+	half := int64(12 * hour)
+	create := now
+	expireA := now + 24*hour
+	expireB := now + half
+
+	a := Lot{
+		LotName: "uuid-a-new",
+		Paths:   []LotPath{{Path: "/a", Recursive: true}},
+		MPA: &MPA{
+			CreationTime:   &Int64FromFloat{Value: create},
+			ExpirationTime: &Int64FromFloat{Value: expireA},
+		},
+	}
+	b := Lot{
+		LotName: "uuid-b-new",
+		Paths:   []LotPath{{Path: "/b", Recursive: true}},
+		MPA: &MPA{
+			CreationTime:   &Int64FromFloat{Value: create},
+			ExpirationTime: &Int64FromFloat{Value: expireB},
+		},
+	}
+	prop.NewLots = []Lot{a, b}
+
+	allocateEpochAwareQuotas(&prop, nil, nil, cfg)
+
+	// Find /a; it should be stamped 600 (min over its 2 epochs), not
+	// 1200 (the larger second-epoch share) and not 400 (which would
+	// be the answer if the divisor incorrectly counted /b's window in
+	// epoch 2 too).
+	var aDed float64 = -1
+	for _, l := range prop.NewLots {
+		if l.Paths[0].Path == "/a" {
+			require.NotNil(t, l.MPA.DedicatedGB)
+			aDed = *l.MPA.DedicatedGB
+		}
+	}
+	assert.InDelta(t, 600.0, aDed, 0.01,
+		"min-over-epochs share for /a should be 600 (root/2 in the epoch where /b is alive)")
+}
+
+// Regression for the planner-clamp+allocator interaction: when an
+// existing sibling has zero stamped quota, it must NOT subtract from
+// the residual capacity. Otherwise a misconfigured cache (or a lot
+// whose quota was zeroed out by an earlier "no feasible share" path)
+// would inflate `usedExisting` by zero (no harm) but the divisor
+// behaviour is what changed: existing siblings shouldn't inflate the
+// divisor either way. This locks that invariant in.
+func TestAllocateEpochAwareQuotas_ExistingZeroQuotaSibling_DoesNotInflateDivisor(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+	cfg := horizonRenewalCfg(now)
+	cfg.HorizonMs = 24 * hour
+	cfg.DefaultLifetimeMs = 24 * hour
+	cfg.RootDedicatedGB = 900.0
+
+	existing := []Lot{makeLotWithDed("uuid-z", "/z", now-hour, now+48*hour, 0.0)}
+	ads := adsForRenewal("/a", "/b", "/c", "/z")
+	prop := renewExpiringLots(cfg, ads, existing)
+	require.Len(t, prop.NewLots, 3) // /z is already covered
+
+	allocateEpochAwareQuotas(&prop, existing, ads, cfg)
+
+	want := 900.0 / 3.0 // existing /z contributes 0 bytes AND 0 to divisor
+	for _, l := range prop.NewLots {
+		require.NotNil(t, l.MPA.DedicatedGB)
+		assert.InDelta(t, want, *l.MPA.DedicatedGB, 0.01)
+	}
+}
+
+// makeLotWithDeletion is like makeLot but also stamps a deletion_time
+// so gcEligibleLots can reason about retention.
+func makeLotWithDeletion(name, path string, create, expire, deletion int64) Lot {
+	l := makeLot(name, path, create, expire)
+	l.MPA.DeletionTime = &Int64FromFloat{Value: deletion}
+	return l
+}
+
+// gcEligibleLots is a pure helper exercising every branch of runGcTick's
+// eligibility decision: skip root/default, skip sentinel, skip
+// missing/zero deletion_time, retention threshold (== eligible, > not
+// eligible), and the retention<=0 fallback to 60 days.
+func TestGcEligibleLots_BranchCoverage(t *testing.T) {
+	const day = int64(24 * 60 * 60 * 1000)
+	const ms = int64(time.Millisecond)
+	_ = ms
+	now := int64(1_000_000 * day) // arbitrary far-future wall clock
+
+	// All have positive non-sentinel windows; only deletion_time varies.
+	lots := []Lot{
+		// root + default are unconditionally skipped.
+		makeLotWithDeletion("root", "/", now-100*day, now-50*day, now-10*day),
+		makeLotWithDeletion("default", "/x", now-100*day, now-50*day, now-10*day),
+
+		// Sentinel lot (all-zero MPA timestamps) — never expires, never GC'd.
+		{
+			LotName: "sentinel",
+			Paths:   []LotPath{{Path: "/sentinel"}},
+			MPA: &MPA{
+				CreationTime:   &Int64FromFloat{Value: 0},
+				ExpirationTime: &Int64FromFloat{Value: 0},
+				DeletionTime:   &Int64FromFloat{Value: 0},
+			},
+		},
+
+		// No MPA / no DeletionTime / DeletionTime=0 → all skipped.
+		{LotName: "no-mpa", Paths: []LotPath{{Path: "/a"}}},
+		{LotName: "no-del", Paths: []LotPath{{Path: "/b"}}, MPA: &MPA{
+			CreationTime:   &Int64FromFloat{Value: now - 5*day},
+			ExpirationTime: &Int64FromFloat{Value: now - 1*day},
+		}},
+		makeLotWithDeletion("zero-del", "/c", now-5*day, now-day, 0),
+
+		// retention=10d, now=now: cutoff = now - 10d.
+		// trigger == cutoff is eligible (<=), trigger > cutoff is not.
+		makeLotWithDeletion("eligible-on-cusp", "/d", now-100*day, now-50*day, now-10*day),
+		makeLotWithDeletion("eligible-old", "/e", now-100*day, now-50*day, now-30*day),
+		makeLotWithDeletion("not-yet", "/f", now-100*day, now-50*day, now-5*day),
+		makeLotWithDeletion("future-del", "/g", now-100*day, now-50*day, now+5*day),
+	}
+
+	got := gcEligibleLots(lots, now, 10*24*time.Hour)
+	assert.ElementsMatch(t, []string{"eligible-on-cusp", "eligible-old"}, got)
+
+	// Empty input → empty output, never nil-deref.
+	assert.Empty(t, gcEligibleLots(nil, now, 10*24*time.Hour))
+
+	// retention<=0 falls back to the 60-day default. Same /e (deleted
+	// 30d ago) is no longer eligible at the longer window.
+	got = gcEligibleLots(lots, now, 0)
+	assert.NotContains(t, got, "eligible-old")
+	assert.NotContains(t, got, "eligible-on-cusp")
+	// But a lot deleted 100d ago would be eligible under the 60d default.
+	old := []Lot{makeLotWithDeletion("very-old", "/h", now-200*day, now-150*day, now-100*day)}
+	assert.Equal(t, []string{"very-old"}, gcEligibleLots(old, now, 0))
+}
+
+// validateLotLifetime accepts:
+//   - any lot with no MPA / missing timestamps (nothing to check)
+//   - the all-zero sentinel
+//   - lots whose span ≤ MaxLotLifetime
+//   - any lot when MaxLotLifetime is unset (no admission cap)
+//
+// and rejects lots whose span exceeds MaxLotLifetime.
+func TestValidateLotLifetime(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+
+	server_utils.ResetTestState()
+	defer server_utils.ResetTestState()
+	viper.Set("Lotman.MaxLotLifetime", "168h") // 7 days
+
+	// Within bound (24h ≤ 168h): accept.
+	in := makeLot("ok", "/a", 0, 24*hour)
+	assert.NoError(t, validateLotLifetime(&in))
+
+	// Exactly at the bound: accept (use <, not <=, in the validator).
+	at := makeLot("at", "/a", 0, 168*hour)
+	assert.NoError(t, validateLotLifetime(&at))
+
+	// Over the bound: reject.
+	over := makeLot("over", "/a", 0, 169*hour)
+	err := validateLotLifetime(&over)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MaxLotLifetime")
+
+	// Sentinel lot: accept regardless of MaxLotLifetime.
+	sentinel := &Lot{
+		LotName: "sentinel",
+		MPA: &MPA{
+			CreationTime:   &Int64FromFloat{Value: 0},
+			ExpirationTime: &Int64FromFloat{Value: 0},
+			DeletionTime:   &Int64FromFloat{Value: 0},
+		},
+	}
+	assert.NoError(t, validateLotLifetime(sentinel))
+
+	// nil / partial MPA: accept (nothing to check).
+	assert.NoError(t, validateLotLifetime(nil))
+	assert.NoError(t, validateLotLifetime(&Lot{LotName: "nil-mpa"}))
+	assert.NoError(t, validateLotLifetime(&Lot{LotName: "no-create", MPA: &MPA{ExpirationTime: &Int64FromFloat{Value: 1}}}))
+
+	// MaxLotLifetime unset → no cap, anything goes.
+	server_utils.ResetTestState()
+	viper.Set("Lotman.MaxLotLifetime", "0")
+	huge := makeLot("huge", "/a", 0, 100000*hour)
+	assert.NoError(t, validateLotLifetime(&huge))
+}
+
+// validateLotUpdateLifetime: when both creation_time and
+// expiration_time are supplied in the update we never need to consult
+// the live lot, so the validator runs entirely in-process. Cover the
+// "updates neither timestamp" early-return, the "supplies both" branch,
+// and the "MPA nil / update nil" guards. The mixed-supply branch
+// (validator does an FFI GetLot) is exercised by integration tests
+// that link against the lotman library.
+func TestValidateLotUpdateLifetime_NoFFIBranches(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+
+	server_utils.ResetTestState()
+	defer server_utils.ResetTestState()
+	viper.Set("Lotman.MaxLotLifetime", "168h")
+
+	// nil update / nil MPA: accept.
+	assert.NoError(t, validateLotUpdateLifetime(nil))
+	assert.NoError(t, validateLotUpdateLifetime(&LotUpdate{LotName: "x"}))
+
+	// Update touches neither timestamp: accept (nothing to check).
+	owner := "alice"
+	assert.NoError(t, validateLotUpdateLifetime(&LotUpdate{
+		LotName: "x",
+		Owner:   &owner,
+		MPA:     &MPA{},
+	}))
+
+	// Update supplies both timestamps within bound: accept.
+	ok := &LotUpdate{
+		LotName: "x",
+		MPA: &MPA{
+			CreationTime:   &Int64FromFloat{Value: 0},
+			ExpirationTime: &Int64FromFloat{Value: 24 * hour},
+		},
+	}
+	assert.NoError(t, validateLotUpdateLifetime(ok))
+
+	// Update supplies both timestamps over bound: reject.
+	over := &LotUpdate{
+		LotName: "x",
+		MPA: &MPA{
+			CreationTime:   &Int64FromFloat{Value: 0},
+			ExpirationTime: &Int64FromFloat{Value: 200 * hour},
+		},
+	}
+	err := validateLotUpdateLifetime(over)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MaxLotLifetime")
+}
+
+// assignSuccessorParents wires up `Parents[0]` from the (path,
+// creation_time) pair of every planned lot, sourcing creation_time
+// from MPA.CreationTime.Value and building the planned-this-tick
+// sibling map from the input slice. This test guards against subtle
+// wiring regressions (e.g. someone passing 0 as the create time, or
+// forgetting to feed prop.NewLots into the planned-parent index).
+func TestAssignSuccessorParents_WiresParentAndCreateTime(t *testing.T) {
+	const hour = int64(60 * 60 * 1000)
+	now := int64(100 * hour)
+
+	// Existing world: parent /a expired in past, with a single
+	// historical child.
+	parentOld := makeLot("uuid-parent-old", "/a", now-2*hour, now-hour)
+	existing := []Lot{parentOld}
+
+	// Planned world: a new /a (this tick) and a new /a/b. The child
+	// must receive the NEW parent's UUID, not "root".
+	newLots := []Lot{
+		makeLot("uuid-parent-new", "/a", now, now+hour),
+		makeLot("uuid-child-new", "/a/b", now, now+hour),
+	}
+
+	assignSuccessorParents(newLots, existing)
+
+	// Find each lot back; assignSuccessorParents mutates in place.
+	parentByPath := map[string]Lot{}
+	for _, l := range newLots {
+		parentByPath[l.Paths[0].Path] = l
+	}
+	a := parentByPath["/a"]
+	ab := parentByPath["/a/b"]
+
+	require.Len(t, a.Parents, 1)
+	assert.Equal(t, "root", a.Parents[0],
+		"top-level /a has no covering ancestor → root")
+
+	require.Len(t, ab.Parents, 1)
+	assert.Equal(t, "uuid-parent-new", ab.Parents[0],
+		"child must attach to the planned-this-tick parent, not the expired old parent or root")
+}
+
+// assignSuccessorParents must tolerate lots without an MPA
+// (creation_time defaulted to 0) without panicking, and must skip lots
+// with no Paths.
+func TestAssignSuccessorParents_HandlesDegenerateLots(t *testing.T) {
+	newLots := []Lot{
+		{LotName: "no-paths"},                               // no Paths → skip
+		{LotName: "no-mpa", Paths: []LotPath{{Path: "/a"}}}, // no MPA → createTime=0
+	}
+	require.NotPanics(t, func() { assignSuccessorParents(newLots, nil) })
+	// "no-paths" is skipped (still has nil Parents); "no-mpa" gets root.
+	assert.Nil(t, newLots[0].Parents)
+	require.Len(t, newLots[1].Parents, 1)
+	assert.Equal(t, "root", newLots[1].Parents[0])
+}
+
+// isMonitoringPath: matches the monitoring root, anything strictly
+// underneath it, and rejects sibling paths whose name shares a prefix
+// (no /monitoringX false-positive).
+func TestIsMonitoringPath(t *testing.T) {
+	mon := server_utils.MonitoringBaseNs
+
+	assert.True(t, isMonitoringPath(mon),
+		"monitoring root is itself a monitoring path")
+	assert.True(t, isMonitoringPath(mon+"/foo"),
+		"strict descendant of monitoring root is a monitoring path")
+	assert.True(t, isMonitoringPath(mon+"/foo/bar"))
+	assert.False(t, isMonitoringPath("/random/ns"))
+	// Sibling that shares a textual prefix but is NOT a path-segment
+	// descendant: mon = "/pelican/monitoring", trickster =
+	// "/pelican/monitoringX/oops" must NOT match.
+	assert.False(t, isMonitoringPath(mon+"X"),
+		"sibling whose name extends the monitoring base must not match")
+	assert.False(t, isMonitoringPath(mon+"X/foo"))
+}

--- a/lotman/renewal_test.go
+++ b/lotman/renewal_test.go
@@ -65,10 +65,10 @@ func TestRenewExpiringLots_NoExistingLots_MintsForEveryNamespace(t *testing.T) {
 	ads := adsForRenewal("/a", "/b")
 
 	prop := renewExpiringLots(cfg, ads, nil)
-	require.Len(t, prop.NewLots, 2)
+	require.Len(t, prop.newLots, 2)
 
 	got := map[string]bool{}
-	for _, l := range prop.NewLots {
+	for _, l := range prop.newLots {
 		require.NotEmpty(t, l.LotName, "new lots must have a UUID name")
 		require.Len(t, l.Paths, 1)
 		got[l.Paths[0].Path] = true
@@ -87,7 +87,7 @@ func TestRenewExpiringLots_CoverageInsidePeriod_NoNewLot(t *testing.T) {
 	// Existing lot covers [now-1h, now+24h) -> no gap inside [now, now+1h).
 	existing := []Lot{makeLot("u1", "/a", now-int64(60*60*1000), now+int64(24*60*60*1000))}
 	prop := renewExpiringLots(cfg, ads, existing)
-	assert.Empty(t, prop.NewLots)
+	assert.Empty(t, prop.newLots)
 }
 
 func TestRenewExpiringLots_GapAtNow_MintsSuccessor(t *testing.T) {
@@ -97,8 +97,8 @@ func TestRenewExpiringLots_GapAtNow_MintsSuccessor(t *testing.T) {
 	// Existing lot expired before now; coverage should restart at now.
 	existing := []Lot{makeLot("u1", "/a", 0, now-1)}
 	prop := renewExpiringLots(cfg, ads, existing)
-	require.Len(t, prop.NewLots, 1)
-	assert.Equal(t, now, prop.NewLots[0].MPA.CreationTime.Value)
+	require.Len(t, prop.newLots, 1)
+	assert.Equal(t, now, prop.newLots[0].MPA.CreationTime.Value)
 }
 
 func TestRenewExpiringLots_GapInsidePeriod_CreationAtPredecessorExpiration(t *testing.T) {
@@ -108,9 +108,9 @@ func TestRenewExpiringLots_GapInsidePeriod_CreationAtPredecessorExpiration(t *te
 	predExp := now + int64(30*60*1000) // expires in 30 min, inside the 1h window.
 	existing := []Lot{makeLot("u1", "/a", now-1000, predExp)}
 	prop := renewExpiringLots(cfg, ads, existing)
-	require.Len(t, prop.NewLots, 1)
+	require.Len(t, prop.newLots, 1)
 	// New lot must start at the predecessor's expiration to avoid overlap.
-	assert.Equal(t, predExp, prop.NewLots[0].MPA.CreationTime.Value)
+	assert.Equal(t, predExp, prop.newLots[0].MPA.CreationTime.Value)
 }
 
 func TestRenewExpiringLots_MonitoringPathSkipped(t *testing.T) {
@@ -118,8 +118,8 @@ func TestRenewExpiringLots_MonitoringPathSkipped(t *testing.T) {
 	cfg := defaultRenewalCfg(now)
 	ads := adsForRenewal("/a", "/pelican/monitoring/probe")
 	prop := renewExpiringLots(cfg, ads, nil)
-	require.Len(t, prop.NewLots, 1)
-	assert.Equal(t, "/a", prop.NewLots[0].Paths[0].Path)
+	require.Len(t, prop.newLots, 1)
+	assert.Equal(t, "/a", prop.newLots[0].Paths[0].Path)
 }
 
 func TestRenewExpiringLots_Idempotent(t *testing.T) {
@@ -128,11 +128,11 @@ func TestRenewExpiringLots_Idempotent(t *testing.T) {
 	ads := adsForRenewal("/a")
 
 	first := renewExpiringLots(cfg, ads, nil)
-	require.Len(t, first.NewLots, 1)
+	require.Len(t, first.newLots, 1)
 
 	// Second pass: feed the freshly-minted lot back as existing.
-	second := renewExpiringLots(cfg, ads, first.NewLots)
-	assert.Empty(t, second.NewLots)
+	second := renewExpiringLots(cfg, ads, first.newLots)
+	assert.Empty(t, second.newLots)
 }
 
 func TestRenewExpiringLots_LifetimeClampedToMax(t *testing.T) {
@@ -141,16 +141,16 @@ func TestRenewExpiringLots_LifetimeClampedToMax(t *testing.T) {
 	cfg.DefaultLifetimeMs = 2 * cfg.MaxLifetimeMs
 	ads := adsForRenewal("/a")
 	prop := renewExpiringLots(cfg, ads, nil)
-	require.Len(t, prop.NewLots, 1)
-	span := prop.NewLots[0].MPA.ExpirationTime.Value - prop.NewLots[0].MPA.CreationTime.Value
+	require.Len(t, prop.newLots, 1)
+	span := prop.newLots[0].MPA.ExpirationTime.Value - prop.newLots[0].MPA.CreationTime.Value
 	assert.Equal(t, cfg.MaxLifetimeMs, span)
 }
 
 func TestRenewExpiringLots_EmptyConfig_NoOp(t *testing.T) {
 	cfg := renewalConfig{NowMs: 0, PeriodMs: 0, DefaultLifetimeMs: 0}
 	prop := renewExpiringLots(cfg, adsForRenewal("/a"), nil)
-	assert.Empty(t, prop.NewLots)
-	assert.NotEmpty(t, prop.Skips)
+	assert.Empty(t, prop.newLots)
+	assert.NotEmpty(t, prop.skips)
 }
 
 // Axiom-3 clamping: a child successor whose default lifetime would exceed
@@ -180,9 +180,9 @@ func TestRenewExpiringLots_ChildClampedToExistingParentExpiration(t *testing.T) 
 	// Find the FIRST /a/b successor — it must be clamped to the
 	// existing parent's window.
 	var child *Lot
-	for i := range prop.NewLots {
-		if prop.NewLots[i].Paths[0].Path == "/a/b" {
-			child = &prop.NewLots[i]
+	for i := range prop.newLots {
+		if prop.newLots[i].Paths[0].Path == "/a/b" {
+			child = &prop.newLots[i]
 			break
 		}
 	}
@@ -209,10 +209,10 @@ func TestRenewExpiringLots_ChildClampedToPlannedParentSuccessor(t *testing.T) {
 		makeLot("u-child", "/a/b", now-int64(60*60*1000), now-1000),
 	}
 	prop := renewExpiringLots(cfg, ads, existing)
-	require.Len(t, prop.NewLots, 2)
+	require.Len(t, prop.newLots, 2)
 
 	var parent, child Lot
-	for _, l := range prop.NewLots {
+	for _, l := range prop.newLots {
 		if l.Paths[0].Path == "/a" {
 			parent = l
 		} else {
@@ -244,9 +244,9 @@ func TestRenewExpiringLots_SkippedWhenParentWindowGivesNoRoom(t *testing.T) {
 		makeLot("u-parent-old", "/a", now-int64(2*60*60*1000), now-1000), // expired
 	}
 	prop := renewExpiringLots(cfg, ads, existing)
-	assert.Empty(t, prop.NewLots, "child cannot fit inside an already-expired parent window")
-	require.NotEmpty(t, prop.Skips)
-	assert.Equal(t, "/a/b", prop.Skips[0].NamespacePath)
+	assert.Empty(t, prop.newLots, "child cannot fit inside an already-expired parent window")
+	require.NotEmpty(t, prop.skips)
+	assert.Equal(t, "/a/b", prop.skips[0].NamespacePath)
 }
 
 // horizonRenewalCfg returns a renewalConfig with the new
@@ -289,11 +289,11 @@ func TestRenewExpiringLots_MultiFillFillsEveryHoleInsideHorizon(t *testing.T) {
 		makeLot("L3", "/a", now+30*hour, now+33*hour),
 	}
 	prop := renewExpiringLots(cfg, ads, existing)
-	require.Len(t, prop.NewLots, 3, "three internal holes must yield three successors")
+	require.Len(t, prop.newLots, 3, "three internal holes must yield three successors")
 
 	// Each successor must start at its hole's left edge and end no
 	// later than the hole's right edge (no overlap with existing lots).
-	for _, l := range prop.NewLots {
+	for _, l := range prop.newLots {
 		create := l.MPA.CreationTime.Value
 		expire := l.MPA.ExpirationTime.Value
 		assert.GreaterOrEqual(t, create, now)
@@ -328,8 +328,8 @@ func TestRenewExpiringLots_GapTrimmingClampsExpirationToHoleEnd(t *testing.T) {
 		makeLot("L-future", "/a", now+2*hour, now+25*hour),
 	}
 	prop := renewExpiringLots(cfg, ads, existing)
-	require.Len(t, prop.NewLots, 1)
-	got := prop.NewLots[0]
+	require.Len(t, prop.newLots, 1)
+	got := prop.newLots[0]
 	assert.Equal(t, now, got.MPA.CreationTime.Value)
 	assert.Equal(t, now+2*hour, got.MPA.ExpirationTime.Value,
 		"expiration must be trimmed to hole_end to avoid same-path overlap")
@@ -349,7 +349,7 @@ func TestRenewExpiringLots_HorizonRefusal_DefersHolesBeyondHorizon(t *testing.T)
 		makeLot("L-now", "/a", now-hour, now+50*hour), // covers [now, now+48h]
 	}
 	prop := renewExpiringLots(cfg, ads, existing)
-	assert.Empty(t, prop.NewLots, "no holes inside horizon → no successors")
+	assert.Empty(t, prop.newLots, "no holes inside horizon → no successors")
 }
 
 // Narrow-gap skip: a hole strictly narrower than MinFillerWidth must be
@@ -371,10 +371,10 @@ func TestRenewExpiringLots_NarrowGapSkipped(t *testing.T) {
 		makeLot("L-future", "/a", now+5*minute, now+25*hour),
 	}
 	prop := renewExpiringLots(cfg, ads, existing)
-	assert.Empty(t, prop.NewLots, "sub-MinFillerWidth gap must not be filled")
-	require.NotEmpty(t, prop.Skips)
+	assert.Empty(t, prop.newLots, "sub-MinFillerWidth gap must not be filled")
+	require.NotEmpty(t, prop.skips)
 	found := false
-	for _, s := range prop.Skips {
+	for _, s := range prop.skips {
 		if s.NamespacePath == "/a" {
 			found = true
 			break
@@ -397,13 +397,13 @@ func TestAllocateEpochAwareQuotas_TopLevelEqualShare(t *testing.T) {
 	ads := adsForRenewal("/a", "/b", "/c") // three siblings under root
 
 	prop := renewExpiringLots(cfg, ads, nil)
-	require.Len(t, prop.NewLots, 3)
+	require.Len(t, prop.newLots, 3)
 
 	allocateEpochAwareQuotas(&prop, nil, ads, cfg)
 
 	// Top-level divisor = N = 3, share = 1000/3 ≈ 333.33.
 	want := 1000.0 / 3.0
-	for _, l := range prop.NewLots {
+	for _, l := range prop.newLots {
 		require.NotNil(t, l.MPA.DedicatedGB, "lot %s missing dedicated_GB", l.LotName)
 		assert.InDelta(t, want, *l.MPA.DedicatedGB, 0.01,
 			"lot %s for %q got %.2f, want ~%.2f",
@@ -423,10 +423,10 @@ func TestAllocateEpochAwareQuotas_NoRootCapacity_StampsZero(t *testing.T) {
 	ads := adsForRenewal("/a")
 
 	prop := renewExpiringLots(cfg, ads, nil)
-	require.Len(t, prop.NewLots, 1)
+	require.Len(t, prop.newLots, 1)
 	allocateEpochAwareQuotas(&prop, nil, ads, cfg)
-	require.NotNil(t, prop.NewLots[0].MPA.DedicatedGB)
-	assert.Equal(t, 0.0, *prop.NewLots[0].MPA.DedicatedGB)
+	require.NotNil(t, prop.newLots[0].MPA.DedicatedGB)
+	assert.Equal(t, 0.0, *prop.newLots[0].MPA.DedicatedGB)
 }
 
 // rootDedicatedGB pulls the dedicated_GB off the root lot in the
@@ -543,12 +543,12 @@ func TestAllocateEpochAwareQuotas_MixedExistingAndPlannedSiblings(t *testing.T) 
 	prop := renewExpiringLots(cfg, ads, existing)
 	// /x is already covered by the existing lot inside the horizon, so
 	// the planner mints only the three new top-level paths.
-	require.Len(t, prop.NewLots, 3, "planner should mint /a, /b, /c (not /x)")
+	require.Len(t, prop.newLots, 3, "planner should mint /a, /b, /c (not /x)")
 
 	allocateEpochAwareQuotas(&prop, existing, ads, cfg)
 
 	want := (1000.0 - 400.0) / 3.0 // = 200
-	for _, l := range prop.NewLots {
+	for _, l := range prop.newLots {
 		require.NotNil(t, l.MPA.DedicatedGB)
 		assert.InDelta(t, want, *l.MPA.DedicatedGB, 0.01,
 			"lot %s for %q got %.2f, want %.2f (residual / nNew, not residual / (nNew+nExisting))",
@@ -576,13 +576,13 @@ func TestAllocateEpochAwareQuotas_DeeperHierarchyDivisor(t *testing.T) {
 	ads := adsForRenewal("/a", "/a/b", "/a/c")
 	prop := renewExpiringLots(cfg, ads, existing)
 	// Only the two children are minted; /a is already covered.
-	require.Len(t, prop.NewLots, 2)
+	require.Len(t, prop.newLots, 2)
 
 	allocateEpochAwareQuotas(&prop, existing, ads, cfg)
 
 	// Parent has 900; two new children + 1 reserve share = 3-way split.
 	want := 900.0 / 3.0
-	for _, l := range prop.NewLots {
+	for _, l := range prop.newLots {
 		require.NotNil(t, l.MPA.DedicatedGB)
 		assert.InDelta(t, want, *l.MPA.DedicatedGB, 0.01,
 			"deeper-level lot %s for %q got %.2f, want %.2f (parent/3, leaving one reserve share)",
@@ -609,8 +609,8 @@ func TestAllocateEpochAwareQuotas_MultiEpoch_MinShareWins(t *testing.T) {
 
 	// Pre-seed a planned-this-tick peer /b that is active only for the
 	// first half of /a's window. We bypass the planner and inject the
-	// peer directly into prop.NewLots so we can control its window.
-	prop := RenewalProposal{}
+	// peer directly into prop.newLots so we can control its window.
+	prop := renewalProposal{}
 	half := int64(12 * hour)
 	create := now
 	expireA := now + 24*hour
@@ -632,7 +632,7 @@ func TestAllocateEpochAwareQuotas_MultiEpoch_MinShareWins(t *testing.T) {
 			ExpirationTime: &Int64FromFloat{Value: expireB},
 		},
 	}
-	prop.NewLots = []Lot{a, b}
+	prop.newLots = []Lot{a, b}
 
 	allocateEpochAwareQuotas(&prop, nil, nil, cfg)
 
@@ -641,7 +641,7 @@ func TestAllocateEpochAwareQuotas_MultiEpoch_MinShareWins(t *testing.T) {
 	// be the answer if the divisor incorrectly counted /b's window in
 	// epoch 2 too).
 	var aDed float64 = -1
-	for _, l := range prop.NewLots {
+	for _, l := range prop.newLots {
 		if l.Paths[0].Path == "/a" {
 			require.NotNil(t, l.MPA.DedicatedGB)
 			aDed = *l.MPA.DedicatedGB
@@ -669,12 +669,12 @@ func TestAllocateEpochAwareQuotas_ExistingZeroQuotaSibling_DoesNotInflateDivisor
 	existing := []Lot{makeLotWithDed("uuid-z", "/z", now-hour, now+48*hour, 0.0)}
 	ads := adsForRenewal("/a", "/b", "/c", "/z")
 	prop := renewExpiringLots(cfg, ads, existing)
-	require.Len(t, prop.NewLots, 3) // /z is already covered
+	require.Len(t, prop.newLots, 3) // /z is already covered
 
 	allocateEpochAwareQuotas(&prop, existing, ads, cfg)
 
 	want := 900.0 / 3.0 // existing /z contributes 0 bytes AND 0 to divisor
-	for _, l := range prop.NewLots {
+	for _, l := range prop.newLots {
 		require.NotNil(t, l.MPA.DedicatedGB)
 		assert.InDelta(t, want, *l.MPA.DedicatedGB, 0.01)
 	}
@@ -852,7 +852,7 @@ func TestValidateLotUpdateLifetime_NoFFIBranches(t *testing.T) {
 // from MPA.CreationTime.Value and building the planned-this-tick
 // sibling map from the input slice. This test guards against subtle
 // wiring regressions (e.g. someone passing 0 as the create time, or
-// forgetting to feed prop.NewLots into the planned-parent index).
+// forgetting to feed prop.newLots into the planned-parent index).
 func TestAssignSuccessorParents_WiresParentAndCreateTime(t *testing.T) {
 	const hour = int64(60 * 60 * 1000)
 	now := int64(100 * hour)

--- a/lotman/scoped_query.go
+++ b/lotman/scoped_query.go
@@ -1,0 +1,160 @@
+//go:build linux && !ppc64le
+
+/***************************************************************
+*
+* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+// Scoped lotman queries used by the renewal scheduler.
+//
+// The previous implementation enumerated every row in the lotman SQLite DB on
+// every tick (listAllLotsFull); at thousands of lots this was wasteful and
+// memory-hungry. This file replaces that O(total lot rows) walk with two
+// targeted multi-step queries built on top of the lotman C API:
+//
+//	getActiveLotsForRenewal(adPaths, nowMs, horizonEndMs)
+//	    Step 1: for each ad path, lotman_get_lots_for_path(p, recursive=true,
+//	            nowMs, horizonEndMs, include_reclaimed=false) returns the
+//	            full Lot objects that win the longest-prefix path-resolution
+//	            contest at any instant in the planning window, plus each
+//	            winner's ancestors (recursive=true). This is the "lots
+//	            covering this namespace and its parents during planning"
+//	            slice the renewal planner needs.
+//	    Step 2: for every lot returned by step 1, recursively expand to
+//	            descendants via lotman_get_children_names + lotman_get_lot_
+//	            as_json. This pulls in stale sublots that no longer have
+//	            advertised namespace ads but still consume parent capacity,
+//	            which the epoch allocator's per-parent sibling sweep needs
+//	            to see for axiom-1 (Σ children dedicated_GB ≤ parent
+//	            dedicated_GB) compliance.
+//	    Step 3: ensure the synthetic "root" lot is present so
+//	            rootDedicatedGB() can find it for top-level capacity.
+//
+//	getGcCandidates(nowMs, retention)
+//	    Single call: lotman_get_lots_past_del(query_time = nowMs - retention,
+//	    recursive=false, include_reclaimed=true). Returns just the names
+//	    eligible for GC; "root" and "default" are filtered defensively
+//	    even though the C side already excludes sentinel lots.
+//
+// All three steps deliberately use existing lotman primitives rather than a
+// dedicated "all lots under path" descendants API, keeping the lotman C
+// surface small.
+
+package lotman
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// getActiveLotsForRenewal returns the union of every lot relevant to the
+// renewal planner across the half-open planning window [nowMs, horizonEndMs).
+// See file header for the multi-step strategy. Replaces listAllLotsFull()
+// for runRenewalTick.
+func getActiveLotsForRenewal(adPaths []string, nowMs, horizonEndMs int64) ([]Lot, error) {
+	seen := map[string]struct{}{}
+	out := make([]Lot, 0, 16)
+	addLot := func(l Lot) {
+		if _, ok := seen[l.LotName]; ok {
+			return
+		}
+		seen[l.LotName] = struct{}{}
+		out = append(out, l)
+	}
+
+	// Step 1: per-ad-path window-aware owners + ancestors.
+	for _, p := range adPaths {
+		lots, err := GetLotsForPath(p, true, nowMs, horizonEndMs, false)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to enumerate lots for namespace %s", p)
+		}
+		for _, l := range lots {
+			addLot(l)
+		}
+	}
+
+	// Step 2: recursively expand to descendants. The epoch allocator's
+	// per-parent sibling sweep needs to see every active sublot to
+	// compute axiom-1-respecting quotas, including stale sublots that
+	// are no longer advertised by the director (those still consume
+	// parent capacity until GC collects them). Iterate via index over a
+	// growing slice so newly-added children are themselves expanded.
+	for i := 0; i < len(out); i++ {
+		head := out[i]
+		// getSelf=false: we already have `head` in `seen`; we only want
+		// its proper children.
+		kids, err := GetChildrenNames(head.LotName, false, false)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list children of lot %s", head.LotName)
+		}
+		for _, name := range kids {
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			child, err := GetLot(name, false)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to fetch child lot %s", name)
+			}
+			if child == nil {
+				continue
+			}
+			addLot(*child)
+		}
+	}
+
+	// Step 3: ensure the synthetic "root" lot is in the result so
+	// rootDedicatedGB() can find it. It is non-expiring and non-path-
+	// owning, so steps 1-2 will not surface it on their own.
+	if _, ok := seen["root"]; !ok {
+		root, err := GetLot("root", false)
+		if err == nil && root != nil {
+			addLot(*root)
+		}
+	}
+
+	return out, nil
+}
+
+// getGcCandidates returns the names of lots whose deletion_time was at least
+// `retention` ago relative to nowMs, filtered to exclude the synthetic
+// root/default lots (which are non-expiring and never garbage-collected).
+// Replaces listAllLotsFull() + the slice-walking gcEligibleLots() inside
+// runGcTick. The pure gcEligibleLots() function is preserved for unit tests
+// that exercise the cutoff arithmetic against synthetic Lot slices.
+func getGcCandidates(nowMs int64, retention time.Duration) ([]string, error) {
+	if retention <= 0 {
+		retention = 60 * 24 * time.Hour
+	}
+	cutoffMs := nowMs - retention.Milliseconds()
+	// recursive=false: cleanup loops want each lot's own deletion_time,
+	// not "deletion_time inherited from any parent". include_reclaimed=
+	// true: a lot can be GC-eligible regardless of whether the purge
+	// plugin already reclaimed it; deletion_time + retention is the
+	// independent forensics-window bound.
+	names, err := GetLotsPastDel(cutoffMs, false, true)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if n == "root" || n == "default" {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}

--- a/lotman/timeline.go
+++ b/lotman/timeline.go
@@ -1,0 +1,193 @@
+//go:build linux && !ppc64le
+
+/***************************************************************
+*
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+// Per-namespace lot timelines.
+//
+// Once a namespace is governed by lots whose names are opaque UUIDs, the
+// renewal scheduler reasons about a *namespace path*, not a single lot:
+// for path P, the lots that ever cover P form a sequence of half-open
+// intervals [creation_time, expiration_time). Together they describe
+// "which lot is responsible for files at P at any given moment".
+//
+// This file provides the small pure helpers the scheduler uses:
+//
+//	lotsForNamespace(P, all)  — filter `all` to the lots whose paths
+//	                            include P, sorted by CreationTime asc.
+//	nextGap(timeline, now)    — given a sorted timeline, return the first
+//	                            point at or after `now` that is NOT
+//	                            covered by any lot in the timeline.
+//	listAllLotsFull()         — fetch every lot from the lotman DB as
+//	                            full Lot structs (FFI-side helper).
+//
+// All time values are Unix milliseconds. The data plane is intentionally
+// pure so it can be unit-tested with synthetic Lot slices.
+
+package lotman
+
+import (
+	"math"
+	"sort"
+)
+
+// lotsForNamespace returns the subset of `all` whose paths[].Path matches
+// nsPath exactly (after path normalisation), ordered by CreationTime asc.
+// Lots without an MPA, or with no recorded creation time, are skipped:
+// they cannot meaningfully participate in a coverage timeline.
+//
+// nsPath is matched via normaliseLotPath so callers may pass either /foo
+// or /foo/ interchangeably.
+func lotsForNamespace(nsPath string, all []Lot) []Lot {
+	target := normaliseLotPath(nsPath)
+	out := make([]Lot, 0, 4)
+	for _, l := range all {
+		if l.MPA == nil || l.MPA.CreationTime == nil {
+			continue
+		}
+		for _, p := range l.Paths {
+			if normaliseLotPath(p.Path) == target {
+				out = append(out, l)
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].MPA.CreationTime.Value < out[j].MPA.CreationTime.Value
+	})
+	return out
+}
+
+// nextGap walks a CreationTime-sorted `timeline` and returns the first
+// point at or after `now` (Unix ms) that no lot in `timeline` covers.
+//
+// Coverage semantics: a lot covers wall-clock t iff
+//
+//	creation_time <= t < expiration_time
+//
+// (half-open right; matches lotman's "lots-past-exp" cutoff exactly).
+//
+// Returns the first uncovered point at or after `now`. Because lots in
+// our model always have a finite expiration_time, a gap is guaranteed to
+// exist eventually; the caller compares the returned point against its
+// planning horizon to decide whether a successor lot is needed *now*.
+//
+// Treatment of edge cases:
+//   - empty timeline -> returns `now`.
+//   - all lots end at or before `now` -> returns `now`.
+//   - lots overlap (predecessor.expiration > successor.creation) ->
+//     the union of intervals is what matters; the gap starts at the
+//     largest expiration that bounds an unbroken run starting at `now`.
+func nextGap(timeline []Lot, now int64) int64 {
+	cursor := now
+	for _, l := range timeline {
+		if l.MPA == nil || l.MPA.CreationTime == nil || l.MPA.ExpirationTime == nil {
+			continue
+		}
+		create := l.MPA.CreationTime.Value
+		expire := l.MPA.ExpirationTime.Value
+		if expire <= cursor {
+			continue
+		}
+		if create > cursor {
+			// Found a hole: cursor sits in a region no lot covers.
+			return cursor
+		}
+		// create <= cursor < expire: lot covers cursor; extend coverage.
+		cursor = expire
+	}
+	return cursor
+}
+
+// nextHole walks a CreationTime-sorted `timeline` and returns the first
+// uncovered region at or after `cursor`, expressed as the half-open
+// interval [holeStart, holeEnd). Coverage semantics match nextGap:
+// a lot covers wall-clock t iff creation_time <= t < expiration_time.
+//
+// holeStart is the first point at or after `cursor` that no lot covers.
+// holeEnd is the creation_time of the next lot whose interval *starts*
+// after holeStart, or `mathMaxMs` (`int64(math.MaxInt64)`) if no such
+// lot exists. Callers can intersect [holeStart, holeEnd) with their own
+// scheduling horizon to bound the fill width.
+//
+// Returns ok=false only when the timeline fully covers `cursor` and
+// every subsequent moment up to the last lot's expiration_time without
+// a break — but since every Pelican lot has a finite expiration_time,
+// in practice ok is always true (the post-last-lot region is itself a
+// hole). Defensive callers should still check.
+//
+// Edge cases:
+//   - empty timeline -> ([cursor, mathMaxMs), true)
+//   - cursor sits inside a covered run: holeStart = end of that run.
+//   - lots overlap: their union is taken; the hole begins at the
+//     largest expiration that bounds an unbroken run.
+//   - subsequent lots after the hole are honoured: holeEnd is set to
+//     the next lot's creation_time, not its expiration_time.
+func nextHole(timeline []Lot, cursor int64) (holeStart, holeEnd int64, ok bool) {
+	const sentinelEnd = math.MaxInt64
+	pos := cursor
+	for i := 0; i < len(timeline); i++ {
+		l := timeline[i]
+		if l.MPA == nil || l.MPA.CreationTime == nil || l.MPA.ExpirationTime == nil {
+			continue
+		}
+		create := l.MPA.CreationTime.Value
+		expire := l.MPA.ExpirationTime.Value
+		if expire <= pos {
+			// Lot already in the past relative to cursor; ignore.
+			continue
+		}
+		if create > pos {
+			// Hole found: [pos, create). The next lot bounds the hole's end.
+			return pos, create, true
+		}
+		// create <= pos < expire: lot covers pos; extend coverage and
+		// continue scanning. A hole may still appear after this lot
+		// ends if a later lot starts strictly after `expire`.
+		pos = expire
+	}
+	// Fell off the end: the post-last-lot region is one big hole.
+	return pos, sentinelEnd, true
+}
+
+// listAllLotsFull returns every lot in the lotman DB as a fully-populated
+// Lot struct, fetching each one via lotman_get_lot_as_json. Reclaimed
+// lots are included so callers can compute reclamation-aware GC eligibility.
+// Returns nil, nil on an empty DB.
+//
+// This is an FFI helper, not a pure function: the rest of timeline.go is
+// pure and unit-testable with synthetic slices, while production callers
+// reach the real database through this entry point.
+func listAllLotsFull() ([]Lot, error) {
+	names, err := ListAllLots()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Lot, 0, len(names))
+	for _, n := range names {
+		l, err := GetLot(n, false)
+		if err != nil {
+			return nil, err
+		}
+		if l == nil {
+			continue
+		}
+		out = append(out, *l)
+	}
+	return out, nil
+}

--- a/lotman/timeline.go
+++ b/lotman/timeline.go
@@ -33,11 +33,11 @@
 //	nextGap(timeline, now)    — given a sorted timeline, return the first
 //	                            point at or after `now` that is NOT
 //	                            covered by any lot in the timeline.
-//	listAllLotsFull()         — fetch every lot from the lotman DB as
-//	                            full Lot structs (FFI-side helper).
 //
 // All time values are Unix milliseconds. The data plane is intentionally
-// pure so it can be unit-tested with synthetic Lot slices.
+// pure so it can be unit-tested with synthetic Lot slices. The FFI-side
+// helpers that fetch the actual Lot population from the lotman DB live in
+// scoped_query.go (renewal/GC ticks) so timeline.go has zero FFI surface.
 
 package lotman
 
@@ -165,29 +165,7 @@ func nextHole(timeline []Lot, cursor int64) (holeStart, holeEnd int64, ok bool) 
 	return pos, sentinelEnd, true
 }
 
-// listAllLotsFull returns every lot in the lotman DB as a fully-populated
-// Lot struct, fetching each one via lotman_get_lot_as_json. Reclaimed
-// lots are included so callers can compute reclamation-aware GC eligibility.
-// Returns nil, nil on an empty DB.
-//
-// This is an FFI helper, not a pure function: the rest of timeline.go is
-// pure and unit-testable with synthetic slices, while production callers
-// reach the real database through this entry point.
-func listAllLotsFull() ([]Lot, error) {
-	names, err := ListAllLots()
-	if err != nil {
-		return nil, err
-	}
-	out := make([]Lot, 0, len(names))
-	for _, n := range names {
-		l, err := GetLot(n, false)
-		if err != nil {
-			return nil, err
-		}
-		if l == nil {
-			continue
-		}
-		out = append(out, *l)
-	}
-	return out, nil
-}
+// listAllLotsFull was removed in favour of the window-aware scoped queries
+// in scoped_query.go (getActiveLotsForRenewal / GC's GetLotsPastDel call).
+// The legacy O(all rows) scan was the renewal scheduler's biggest scaling
+// pain point; both ticks now scope work to O(active subtree size).

--- a/lotman/timeline_test.go
+++ b/lotman/timeline_test.go
@@ -1,0 +1,107 @@
+//go:build linux && !ppc64le
+
+/***************************************************************
+*
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+***************************************************************/
+
+package lotman
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// makeLot is a tiny helper for constructing synthetic Lot values whose
+// only populated fields are the bits of MPA the timeline helpers care
+// about. Path sets a single recursive path entry.
+func makeLot(name, path string, create, expire int64) Lot {
+	return Lot{
+		LotName: name,
+		Paths:   []LotPath{{Path: path, Recursive: true}},
+		MPA: &MPA{
+			CreationTime:   &Int64FromFloat{Value: create},
+			ExpirationTime: &Int64FromFloat{Value: expire},
+		},
+	}
+}
+
+func TestLotsForNamespace_FiltersAndSorts(t *testing.T) {
+	all := []Lot{
+		makeLot("u3", "/foo", 300, 400),
+		makeLot("u1", "/foo", 100, 200),
+		makeLot("v1", "/bar", 50, 150),
+		makeLot("u2", "/foo/", 200, 300), // trailing slash should normalise.
+	}
+	got := lotsForNamespace("/foo", all)
+	if assert.Len(t, got, 3) {
+		assert.Equal(t, "u1", got[0].LotName)
+		assert.Equal(t, "u2", got[1].LotName)
+		assert.Equal(t, "u3", got[2].LotName)
+	}
+}
+
+func TestLotsForNamespace_SkipsLotsWithoutCreation(t *testing.T) {
+	all := []Lot{
+		{LotName: "no-mpa", Paths: []LotPath{{Path: "/p"}}},
+		{LotName: "no-create", Paths: []LotPath{{Path: "/p"}}, MPA: &MPA{}},
+		makeLot("ok", "/p", 1, 2),
+	}
+	got := lotsForNamespace("/p", all)
+	if assert.Len(t, got, 1) {
+		assert.Equal(t, "ok", got[0].LotName)
+	}
+}
+
+func TestNextGap_EmptyTimeline(t *testing.T) {
+	assert.Equal(t, int64(42), nextGap(nil, 42))
+}
+
+func TestNextGap_AllLotsBeforeNow(t *testing.T) {
+	timeline := []Lot{
+		makeLot("a", "/p", 1, 2),
+		makeLot("b", "/p", 3, 4),
+	}
+	assert.Equal(t, int64(100), nextGap(timeline, 100))
+}
+
+func TestNextGap_CoveredByOne(t *testing.T) {
+	timeline := []Lot{makeLot("a", "/p", 0, 1000)}
+	assert.Equal(t, int64(1000), nextGap(timeline, 500))
+}
+
+func TestNextGap_HoleBetweenAdjacentLots(t *testing.T) {
+	timeline := []Lot{
+		makeLot("a", "/p", 0, 100),
+		makeLot("b", "/p", 200, 300),
+	}
+	// at t=50, "a" covers; coverage extends to 100; next lot starts at 200 -> hole at 100.
+	assert.Equal(t, int64(100), nextGap(timeline, 50))
+}
+
+func TestNextGap_OverlappingCoverage(t *testing.T) {
+	timeline := []Lot{
+		makeLot("a", "/p", 0, 200),
+		makeLot("b", "/p", 100, 400),
+		makeLot("c", "/p", 350, 500),
+	}
+	// Union = [0, 500); from now=10 the next gap is at 500.
+	assert.Equal(t, int64(500), nextGap(timeline, 10))
+}
+
+func TestNextGap_NowInsideHole(t *testing.T) {
+	timeline := []Lot{
+		makeLot("a", "/p", 0, 100),
+		makeLot("b", "/p", 200, 300),
+	}
+	// now=150 sits in the hole; the gap is at now.
+	assert.Equal(t, int64(150), nextGap(timeline, 150))
+}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -261,7 +261,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Lotman.EnabledPolicy": false,
 	"Lotman.LibLocation": false,
 	"Lotman.LotHome": false,
-	"Lotman.LotRetention": false,
+	"Lotman.LotRecordRetention": false,
 	"Lotman.MaxLotLifetime": false,
 	"Lotman.MinFillerWidth": false,
 	"Lotman.PolicyDefinitions": false,
@@ -1050,7 +1050,7 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Logging.Client.ProgressInterval": func(c *Config) time.Duration { return c.Logging.Client.ProgressInterval },
 	"Lotman.DefaultLotDeletionLifetime": func(c *Config) time.Duration { return c.Lotman.DefaultLotDeletionLifetime },
 	"Lotman.DefaultLotExpirationLifetime": func(c *Config) time.Duration { return c.Lotman.DefaultLotExpirationLifetime },
-	"Lotman.LotRetention": func(c *Config) time.Duration { return c.Lotman.LotRetention },
+	"Lotman.LotRecordRetention": func(c *Config) time.Duration { return c.Lotman.LotRecordRetention },
 	"Lotman.MaxLotLifetime": func(c *Config) time.Duration { return c.Lotman.MaxLotLifetime },
 	"Lotman.MinFillerWidth": func(c *Config) time.Duration { return c.Lotman.MinFillerWidth },
 	"Lotman.RenewalCheckInterval": func(c *Config) time.Duration { return c.Lotman.RenewalCheckInterval },
@@ -1337,7 +1337,7 @@ var allParameterNames = []string{
 	"Lotman.EnabledPolicy",
 	"Lotman.LibLocation",
 	"Lotman.LotHome",
-	"Lotman.LotRetention",
+	"Lotman.LotRecordRetention",
 	"Lotman.MaxLotLifetime",
 	"Lotman.MinFillerWidth",
 	"Lotman.PolicyDefinitions",
@@ -1950,7 +1950,7 @@ var (
 	Logging_Client_ProgressInterval = DurationParam{"Logging.Client.ProgressInterval"}
 	Lotman_DefaultLotDeletionLifetime = DurationParam{"Lotman.DefaultLotDeletionLifetime"}
 	Lotman_DefaultLotExpirationLifetime = DurationParam{"Lotman.DefaultLotExpirationLifetime"}
-	Lotman_LotRetention = DurationParam{"Lotman.LotRetention"}
+	Lotman_LotRecordRetention = DurationParam{"Lotman.LotRecordRetention"}
 	Lotman_MaxLotLifetime = DurationParam{"Lotman.MaxLotLifetime"}
 	Lotman_MinFillerWidth = DurationParam{"Lotman.MinFillerWidth"}
 	Lotman_RenewalCheckInterval = DurationParam{"Lotman.RenewalCheckInterval"}
@@ -2374,7 +2374,7 @@ func init() {
 		"Logging.Client.ProgressInterval": Logging_Client_ProgressInterval,
 		"Lotman.DefaultLotDeletionLifetime": Lotman_DefaultLotDeletionLifetime,
 		"Lotman.DefaultLotExpirationLifetime": Lotman_DefaultLotExpirationLifetime,
-		"Lotman.LotRetention": Lotman_LotRetention,
+		"Lotman.LotRecordRetention": Lotman_LotRecordRetention,
 		"Lotman.MaxLotLifetime": Lotman_MaxLotLifetime,
 		"Lotman.MinFillerWidth": Lotman_MinFillerWidth,
 		"Lotman.RenewalCheckInterval": Lotman_RenewalCheckInterval,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -261,7 +261,12 @@ var runtimeConfigurableMap = map[string]bool{
 	"Lotman.EnabledPolicy": false,
 	"Lotman.LibLocation": false,
 	"Lotman.LotHome": false,
+	"Lotman.LotRetention": false,
+	"Lotman.MaxLotLifetime": false,
+	"Lotman.MinFillerWidth": false,
 	"Lotman.PolicyDefinitions": false,
+	"Lotman.RenewalCheckInterval": false,
+	"Lotman.SchedulingHorizon": false,
 	"MinimumDownloadSpeed": false,
 	"Monitoring.AggregatePrefixes": false,
 	"Monitoring.DataLocation": false,
@@ -1045,6 +1050,11 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Logging.Client.ProgressInterval": func(c *Config) time.Duration { return c.Logging.Client.ProgressInterval },
 	"Lotman.DefaultLotDeletionLifetime": func(c *Config) time.Duration { return c.Lotman.DefaultLotDeletionLifetime },
 	"Lotman.DefaultLotExpirationLifetime": func(c *Config) time.Duration { return c.Lotman.DefaultLotExpirationLifetime },
+	"Lotman.LotRetention": func(c *Config) time.Duration { return c.Lotman.LotRetention },
+	"Lotman.MaxLotLifetime": func(c *Config) time.Duration { return c.Lotman.MaxLotLifetime },
+	"Lotman.MinFillerWidth": func(c *Config) time.Duration { return c.Lotman.MinFillerWidth },
+	"Lotman.RenewalCheckInterval": func(c *Config) time.Duration { return c.Lotman.RenewalCheckInterval },
+	"Lotman.SchedulingHorizon": func(c *Config) time.Duration { return c.Lotman.SchedulingHorizon },
 	"Monitoring.DataRetention": func(c *Config) time.Duration { return c.Monitoring.DataRetention },
 	"Monitoring.StorageHealthCheckInterval": func(c *Config) time.Duration { return c.Monitoring.StorageHealthCheckInterval },
 	"Monitoring.TokenExpiresIn": func(c *Config) time.Duration { return c.Monitoring.TokenExpiresIn },
@@ -1327,7 +1337,12 @@ var allParameterNames = []string{
 	"Lotman.EnabledPolicy",
 	"Lotman.LibLocation",
 	"Lotman.LotHome",
+	"Lotman.LotRetention",
+	"Lotman.MaxLotLifetime",
+	"Lotman.MinFillerWidth",
 	"Lotman.PolicyDefinitions",
+	"Lotman.RenewalCheckInterval",
+	"Lotman.SchedulingHorizon",
 	"MinimumDownloadSpeed",
 	"Monitoring.AggregatePrefixes",
 	"Monitoring.DataLocation",
@@ -1935,6 +1950,11 @@ var (
 	Logging_Client_ProgressInterval = DurationParam{"Logging.Client.ProgressInterval"}
 	Lotman_DefaultLotDeletionLifetime = DurationParam{"Lotman.DefaultLotDeletionLifetime"}
 	Lotman_DefaultLotExpirationLifetime = DurationParam{"Lotman.DefaultLotExpirationLifetime"}
+	Lotman_LotRetention = DurationParam{"Lotman.LotRetention"}
+	Lotman_MaxLotLifetime = DurationParam{"Lotman.MaxLotLifetime"}
+	Lotman_MinFillerWidth = DurationParam{"Lotman.MinFillerWidth"}
+	Lotman_RenewalCheckInterval = DurationParam{"Lotman.RenewalCheckInterval"}
+	Lotman_SchedulingHorizon = DurationParam{"Lotman.SchedulingHorizon"}
 	Monitoring_DataRetention = DurationParam{"Monitoring.DataRetention"}
 	Monitoring_StorageHealthCheckInterval = DurationParam{"Monitoring.StorageHealthCheckInterval"}
 	Monitoring_TokenExpiresIn = DurationParam{"Monitoring.TokenExpiresIn"}
@@ -2354,6 +2374,11 @@ func init() {
 		"Logging.Client.ProgressInterval": Logging_Client_ProgressInterval,
 		"Lotman.DefaultLotDeletionLifetime": Lotman_DefaultLotDeletionLifetime,
 		"Lotman.DefaultLotExpirationLifetime": Lotman_DefaultLotExpirationLifetime,
+		"Lotman.LotRetention": Lotman_LotRetention,
+		"Lotman.MaxLotLifetime": Lotman_MaxLotLifetime,
+		"Lotman.MinFillerWidth": Lotman_MinFillerWidth,
+		"Lotman.RenewalCheckInterval": Lotman_RenewalCheckInterval,
+		"Lotman.SchedulingHorizon": Lotman_SchedulingHorizon,
 		"Monitoring.DataRetention": Monitoring_DataRetention,
 		"Monitoring.StorageHealthCheckInterval": Monitoring_StorageHealthCheckInterval,
 		"Monitoring.TokenExpiresIn": Monitoring_TokenExpiresIn,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -216,7 +216,7 @@ type Config struct {
 		EnabledPolicy string `mapstructure:"enabledpolicy" yaml:"EnabledPolicy"`
 		LibLocation string `mapstructure:"liblocation" yaml:"LibLocation"`
 		LotHome string `mapstructure:"lothome" yaml:"LotHome"`
-		LotRetention time.Duration `mapstructure:"lotretention" yaml:"LotRetention"`
+		LotRecordRetention time.Duration `mapstructure:"lotrecordretention" yaml:"LotRecordRetention"`
 		MaxLotLifetime time.Duration `mapstructure:"maxlotlifetime" yaml:"MaxLotLifetime"`
 		MinFillerWidth time.Duration `mapstructure:"minfillerwidth" yaml:"MinFillerWidth"`
 		PolicyDefinitions any `mapstructure:"policydefinitions" yaml:"PolicyDefinitions"`
@@ -676,7 +676,7 @@ type configWithType struct {
 		EnabledPolicy struct { Type string; Value string }
 		LibLocation struct { Type string; Value string }
 		LotHome struct { Type string; Value string }
-		LotRetention struct { Type string; Value time.Duration }
+		LotRecordRetention struct { Type string; Value time.Duration }
 		MaxLotLifetime struct { Type string; Value time.Duration }
 		MinFillerWidth struct { Type string; Value time.Duration }
 		PolicyDefinitions struct { Type string; Value any }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -216,7 +216,12 @@ type Config struct {
 		EnabledPolicy string `mapstructure:"enabledpolicy" yaml:"EnabledPolicy"`
 		LibLocation string `mapstructure:"liblocation" yaml:"LibLocation"`
 		LotHome string `mapstructure:"lothome" yaml:"LotHome"`
+		LotRetention time.Duration `mapstructure:"lotretention" yaml:"LotRetention"`
+		MaxLotLifetime time.Duration `mapstructure:"maxlotlifetime" yaml:"MaxLotLifetime"`
+		MinFillerWidth time.Duration `mapstructure:"minfillerwidth" yaml:"MinFillerWidth"`
 		PolicyDefinitions any `mapstructure:"policydefinitions" yaml:"PolicyDefinitions"`
+		RenewalCheckInterval time.Duration `mapstructure:"renewalcheckinterval" yaml:"RenewalCheckInterval"`
+		SchedulingHorizon time.Duration `mapstructure:"schedulinghorizon" yaml:"SchedulingHorizon"`
 	} `mapstructure:"lotman" yaml:"Lotman"`
 	MinimumDownloadSpeed int `mapstructure:"minimumdownloadspeed" yaml:"MinimumDownloadSpeed"`
 	Monitoring struct {
@@ -671,7 +676,12 @@ type configWithType struct {
 		EnabledPolicy struct { Type string; Value string }
 		LibLocation struct { Type string; Value string }
 		LotHome struct { Type string; Value string }
+		LotRetention struct { Type string; Value time.Duration }
+		MaxLotLifetime struct { Type string; Value time.Duration }
+		MinFillerWidth struct { Type string; Value time.Duration }
 		PolicyDefinitions struct { Type string; Value any }
+		RenewalCheckInterval struct { Type string; Value time.Duration }
+		SchedulingHorizon struct { Type string; Value time.Duration }
 	}
 	MinimumDownloadSpeed struct { Type string; Value int }
 	Monitoring struct {

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -67,7 +67,7 @@ pfc.prefetch 0
 pfc.writequeue 16 4
 pfc.ram 4g
 # Note that I assume we've already validated file directives -- if we have one defined, we _must_ have all three defined, which should be checked before we get here.
-pfc.diskusage {{if .Cache.LowWatermark}}{{.Cache.LowWatermark}}{{else}}0.90{{end}} {{if .Cache.HighWaterMark}}{{.Cache.HighWaterMark}}{{else}}0.95{{end}}{{if .Cache.FilesBaseSize}} files {{.Cache.FilesBaseSize}} {{.Cache.FilesNominalSize}} {{.Cache.FilesMaxSize}}{{end}} purgeinterval 300s
+pfc.diskusage {{if .Cache.LowWatermark}}{{.Cache.LowWatermark}}{{else}}0.90{{end}} {{if .Cache.HighWaterMark}}{{.Cache.HighWaterMark}}{{else}}0.95{{end}}{{if .Cache.FilesBaseSize}} files {{.Cache.FilesBaseSize}} {{.Cache.FilesNominalSize}} {{.Cache.FilesMaxSize}}{{end}} purgeinterval 300s{{if .Cache.LotmanCfg.PurgeColdFilesAge}} purgecoldfiles {{.Cache.LotmanCfg.PurgeColdFilesAge}}{{end}}
 xrootd.fslib ++ throttle # throttle plugin is needed to calculate server IO load
 {{- if .Cache.LotmanCfg.Enabled}}
 pfc.purgelib libXrdPurgeLotMan.so {{.Cache.LotmanCfg.LotHome}} {{range  $value := .Cache.LotmanCfg.PurgeOrder}}{{$value}} {{end}}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -135,6 +135,13 @@ type (
 		// to pfc.diskusage's purgecoldfiles directive. Sourced from
 		// Lotman.MaxLotLifetime so files untouched for longer than the maximum
 		// lot lifetime are evicted independently of the high watermark.
+		// This is a drainage mechanism: without it, the renewal scheduler's
+		// continuous re-issuance of successor lots over advertised namespace
+		// paths would keep every cached file associated with a live lot, and
+		// the watermark-driven eviction loop would never reclaim long-cold
+		// files on caches that stay below the high watermark. In other
+		// words, perpetually-extended lots could otherwise accrue unused
+		// cruft indefinitely; this knob lets pfc evict that cruft.
 		PurgeColdFilesAge string
 	}
 
@@ -1487,28 +1494,12 @@ func genLoggingConfig(input string, logMap loggingMap) (string, error) {
 
 // purgeColdFilesAgeFromMaxLotLifetime renders Lotman.MaxLotLifetime into
 // the xrootd-formatted age string consumed by the pfc.diskusage
-// purgecoldfiles directive (e.g. "604800s"), enforcing the directive's
-// own [1h, 360d] domain. Returns an error rather than a clamp because
-// a misconfigured cap is exactly the case where silent fallback would
-// hide the bug from operators.
-//
-// Extracted from ConfigXrootd so the validation can be unit-tested
-// without spinning up the entire xrootd config builder.
+// purgecoldfiles directive (e.g. "604800s"). The [1h, 360d] domain
+// check has been moved to config/config.go so the operator sees the
+// rejection at boot rather than mid-startup of the xrootd config
+// builder; this function is now a pure formatter and assumes its input
+// is already in range.
 func purgeColdFilesAgeFromMaxLotLifetime(maxLotLifetime time.Duration) (string, error) {
-	const (
-		minAge = time.Hour
-		maxAge = 360 * 24 * time.Hour
-	)
-	if maxLotLifetime < minAge {
-		return "", errors.Errorf(
-			"Lotman.MaxLotLifetime (%s) is below the minimum allowed value of 1h",
-			maxLotLifetime)
-	}
-	if maxLotLifetime > maxAge {
-		return "", errors.Errorf(
-			"Lotman.MaxLotLifetime (%s) exceeds the maximum allowed value of 360d",
-			maxLotLifetime)
-	}
 	return strconv.FormatInt(int64(maxLotLifetime.Seconds()), 10) + "s", nil
 }
 

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -131,6 +131,11 @@ type (
 		Enabled    bool
 		LotHome    string
 		PurgeOrder []string
+		// PurgeColdFilesAge is the xrootd-formatted age (e.g. "604800s") passed
+		// to pfc.diskusage's purgecoldfiles directive. Sourced from
+		// Lotman.MaxLotLifetime so files untouched for longer than the maximum
+		// lot lifetime are evicted independently of the high watermark.
+		PurgeColdFilesAge string
 	}
 
 	CacheConfig struct {
@@ -1162,6 +1167,23 @@ func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
 				return "", errors.Errorf("lotman policy %s has an undefined purge order", enabledPolicy)
 			}
 			lotmanCfg.PurgeOrder = purgeOrder
+
+			// Tie pfc's age-based purge to the maximum lot lifetime. The renewal
+			// scheduler continuously schedules successor lots over advertised
+			// namespace paths, so files under those paths are always associated
+			// with a live lot. Without an age-based purge, watermark-driven
+			// eviction never fires on a cache that stays below the high
+			// watermark, and cold cruft accumulates indefinitely. The xrootd
+			// purgecoldfiles directive evicts files untouched for longer than
+			// the supplied age regardless of fill level.
+			maxLotLifetime := param.Lotman_MaxLotLifetime.GetDuration()
+			if maxLotLifetime > 0 {
+				ageStr, err := purgeColdFilesAgeFromMaxLotLifetime(maxLotLifetime)
+				if err != nil {
+					return "", err
+				}
+				lotmanCfg.PurgeColdFilesAge = ageStr
+			}
 		}
 		xrdConfig.Cache.LotmanCfg = lotmanCfg
 	}
@@ -1461,6 +1483,33 @@ func genLoggingConfig(input string, logMap loggingMap) (string, error) {
 	}
 
 	return level, nil
+}
+
+// purgeColdFilesAgeFromMaxLotLifetime renders Lotman.MaxLotLifetime into
+// the xrootd-formatted age string consumed by the pfc.diskusage
+// purgecoldfiles directive (e.g. "604800s"), enforcing the directive's
+// own [1h, 360d] domain. Returns an error rather than a clamp because
+// a misconfigured cap is exactly the case where silent fallback would
+// hide the bug from operators.
+//
+// Extracted from ConfigXrootd so the validation can be unit-tested
+// without spinning up the entire xrootd config builder.
+func purgeColdFilesAgeFromMaxLotLifetime(maxLotLifetime time.Duration) (string, error) {
+	const (
+		minAge = time.Hour
+		maxAge = 360 * 24 * time.Hour
+	)
+	if maxLotLifetime < minAge {
+		return "", errors.Errorf(
+			"Lotman.MaxLotLifetime (%s) is below the minimum allowed value of 1h",
+			maxLotLifetime)
+	}
+	if maxLotLifetime > maxAge {
+		return "", errors.Errorf(
+			"Lotman.MaxLotLifetime (%s) exceeds the maximum allowed value of 360d",
+			maxLotLifetime)
+	}
+	return strconv.FormatInt(int64(maxLotLifetime.Seconds()), 10) + "s", nil
 }
 
 // mapXrootdLogLevels is utilized to map Pelican config values to Xrootd ones

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -876,31 +876,22 @@ func TestConfigUpdatesHealthOKWhenFresh(t *testing.T) {
 // directive silently rejects, so Pelican must reject at config time
 // rather than emit an unparsable directive.
 func TestPurgeColdFilesAgeFromMaxLotLifetime(t *testing.T) {
+	// Domain validation has moved to config/config.go; this test
+	// pins only the formatter behaviour. See TestValidateLotmanConfig
+	// (or equivalent) in pelican/config for [1h, 360d] rejection.
 	cases := []struct {
-		name    string
-		in      time.Duration
-		want    string
-		wantErr string
+		name string
+		in   time.Duration
+		want string
 	}{
-		{"one hour minimum accepted", time.Hour, "3600s", ""},
-		{"one day accepted", 24 * time.Hour, "86400s", ""},
-		{"week accepted", 7 * 24 * time.Hour, "604800s", ""},
-		{"360 days maximum accepted", 360 * 24 * time.Hour, "31104000s", ""},
-
-		{"30 minutes rejected", 30 * time.Minute, "", "minimum allowed value of 1h"},
-		{"59 minutes rejected", 59 * time.Minute, "", "minimum allowed value of 1h"},
-		{"361 days rejected", 361 * 24 * time.Hour, "", "maximum allowed value of 360d"},
-		{"1 year rejected", 365 * 24 * time.Hour, "", "maximum allowed value of 360d"},
+		{"one hour minimum accepted", time.Hour, "3600s"},
+		{"one day accepted", 24 * time.Hour, "86400s"},
+		{"week accepted", 7 * 24 * time.Hour, "604800s"},
+		{"360 days maximum accepted", 360 * 24 * time.Hour, "31104000s"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := purgeColdFilesAgeFromMaxLotLifetime(tc.in)
-			if tc.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.wantErr)
-				assert.Empty(t, got)
-				return
-			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		})

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -868,3 +868,41 @@ func TestConfigUpdatesHealthOKWhenFresh(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, metrics.StatusOK.String(), status)
 }
+
+// purgeColdFilesAgeFromMaxLotLifetime is the small validator used by
+// ConfigXrootd to translate Lotman.MaxLotLifetime into the
+// pfc.diskusage purgecoldfiles age. xrootd accepts ages in [1h, 360d]
+// (see XrdPfcConfiguration.cc::a2tm); below or above that range the
+// directive silently rejects, so Pelican must reject at config time
+// rather than emit an unparsable directive.
+func TestPurgeColdFilesAgeFromMaxLotLifetime(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      time.Duration
+		want    string
+		wantErr string
+	}{
+		{"one hour minimum accepted", time.Hour, "3600s", ""},
+		{"one day accepted", 24 * time.Hour, "86400s", ""},
+		{"week accepted", 7 * 24 * time.Hour, "604800s", ""},
+		{"360 days maximum accepted", 360 * 24 * time.Hour, "31104000s", ""},
+
+		{"30 minutes rejected", 30 * time.Minute, "", "minimum allowed value of 1h"},
+		{"59 minutes rejected", 59 * time.Minute, "", "minimum allowed value of 1h"},
+		{"361 days rejected", 361 * 24 * time.Hour, "", "maximum allowed value of 360d"},
+		{"1 year rejected", 365 * 24 * time.Hour, "", "maximum allowed value of 360d"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := purgeColdFilesAgeFromMaxLotLifetime(tc.in)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Without a renewal scheduler, lot windows for namespace paths expire and are not replaced, progressively stranding cached files in lots that have no live coverage and breaking per-namespace quota enforcement. This commit adds the machinery to keep continuous lot coverage and bound on-disk file age.

# Renewal Scheduler:
LaunchRenewalRoutine wakes every Lotman.RenewalCheckInterval and, for each namespace path advertised by the director, walks the post-tick timeline and fills every gap inside Lotman.SchedulingHorizon — not just the next one. Multi-fill is necessary because a cold-start or missed tick can leave multiple holes; filling only the nearest would require multiple wakeups to catch up.

Each new lot's window is clipped to its effective parent's remaining span so lotman's strict hierarchy (axiom 3) is never violated. Parents are processed before children so a freshly-planned parent successor is visible when children are evaluated. Lots whose creation_time would fall beyond the scheduling horizon are deferred to a future tick, keeping scheduling decisions tied to a meaningful look-ahead window.

# Epoch-aware quota stamping (epoch.go):
When a new lot's window spans multiple "epochs" — intervals defined by the creation and expiration boundaries of its siblings and parent — the share it can safely claim varies across those epochs. Stamping the share at the start of the window and ignoring later epochs could lead to quota overcommitment. allocateEpochAwareQuotas takes the minimum share over all epochs the lot will occupy, matching the same fairshare logic in lot_tree.go::distribute (N+1 divisor at top level, N+2 deeper).

# Lot GC (renewal.go):
Old lot rows accumulate in the lotman SQLite database indefinitely without a cleanup mechanism. LaunchLotGcRoutine runs on a fixed 24-hour cadence and removes any lot whose deletion_time is at least Lotman.LotRetention in the past. A lot is assumed to have been reclaimed by the storage layer at or before deletion_time, so deletion_time alone is the GC trigger. The retention window (default 60 days) gives operators a forensics window before the row disappears.

Age-based purge (xrootd_config.go, xrootd-cache.cfg): Because the renewal scheduler continuously issues successor lots over advertised namespace paths, every cached file is always associated with a live lot. Watermark-driven eviction therefore never fires on a cache that stays below Cache.HighWaterMark, and cold files accumulate indefinitely. To bound on-disk file age independently of fill level, Lotman.MaxLotLifetime is now wired to xrootd's pfc.diskusage purgecoldfiles directive when Cache.EnableLotman is true. xrootd will evict files untouched for longer than MaxLotLifetime regardless of watermarks. Because this value is passed directly to xrootd, it must fall within xrootd's accepted range [1h, 360d]; values outside this range are rejected at startup rather than silently clamped.

# Configuration:
New parameters: Lotman.SchedulingHorizon (48h), Lotman.RenewalCheckInterval (1h), Lotman.MinFillerWidth (0), Lotman.LotRetention (1440h), Lotman.MaxLotLifetime (168h). MinFillerWidth defaults to 0 (fill all gaps); it exists as a knob for operators who want to suppress very narrow filler lots. LotGcInterval is not configurable; 24h is the right cadence and exposing it adds complexity without benefit.